### PR TITLE
Fix bugs #18-20: sync data loss, snapshot cron, external play history

### DIFF
--- a/backend/routers/digest.py
+++ b/backend/routers/digest.py
@@ -31,14 +31,14 @@ def _resolve_album_metadata(
     album_ids: list[str], album_cache: list[dict], sp: spotipy.Spotify
 ):
     """Resolve metadata for album IDs. Uses cache first, then Spotify API fallback."""
-    lookup = {a["spotify_id"]: a for a in album_cache}
+    lookup = {a["service_id"]: a for a in album_cache}
     resolved = []
     for aid in album_ids:
         if aid in lookup:
             a = lookup[aid]
             resolved.append(
                 {
-                    "spotify_id": aid,
+                    "service_id": aid,
                     "name": a["name"],
                     "artists": a["artists"],
                     "image_url": a.get("image_url"),
@@ -51,7 +51,7 @@ def _resolve_album_metadata(
                 largest = max(images, key=lambda i: i.get("height", 0), default=None)
                 resolved.append(
                     {
-                        "spotify_id": aid,
+                        "service_id": aid,
                         "name": album["name"],
                         "artists": [a["name"] for a in album.get("artists", [])],
                         "image_url": largest["url"] if largest else None,
@@ -60,7 +60,7 @@ def _resolve_album_metadata(
             except Exception:
                 resolved.append(
                     {
-                        "spotify_id": aid,
+                        "service_id": aid,
                         "name": None,
                         "artists": None,
                         "image_url": None,
@@ -109,7 +109,7 @@ def get_digest(
 
     all_ids = set(added_ids) | set(removed_ids) | set(listened_ids)
     metadata = _resolve_album_metadata(list(all_ids), album_cache, sp)
-    meta_lookup = {m["spotify_id"]: m for m in metadata}
+    meta_lookup = {m["service_id"]: m for m in metadata}
 
     def enrich(ids):
         return [meta_lookup[aid] for aid in ids if aid in meta_lookup]
@@ -153,7 +153,7 @@ def create_snapshot(
 
     created = 0
     for row in users_with_cache.data:
-        album_ids = [a["spotify_id"] for a in row["albums"]]
+        album_ids = [a["service_id"] for a in row["albums"]]
         total = len(album_ids)
         db.table("library_snapshots").upsert(
             {
@@ -198,7 +198,7 @@ def ensure_snapshot(
             detail="Library cache is empty. Open the app to sync your library first.",
         )
 
-    album_ids = [a["spotify_id"] for a in album_cache]
+    album_ids = [a["service_id"] for a in album_cache]
     total = len(album_ids)
 
     db.table("library_snapshots").upsert(

--- a/backend/routers/home.py
+++ b/backend/routers/home.py
@@ -31,8 +31,58 @@ def log_play(
     return Response(status_code=204)
 
 
+@router.post("/history/sync")
+def sync_history(
+    db: Client = Depends(get_authed_db),
+    sp: spotipy.Spotify = Depends(get_user_spotify),
+    user: dict = Depends(get_current_user),
+):
+    results = sp.current_user_recently_played(limit=50)
+    items = results.get("items", [])
+    if not items:
+        return {"synced": 0}
+
+    # Parse played_at timestamps and find time range
+    parsed = []
+    for item in items:
+        album_id = item["track"]["album"]["id"]
+        played_at = item["played_at"]
+        parsed.append({"album_id": album_id, "played_at": played_at})
+
+    timestamps = [p["played_at"] for p in parsed]
+    min_ts = min(timestamps)
+    max_ts = max(timestamps)
+
+    # Fetch existing rows in this time range to avoid duplicates
+    existing_rows = (
+        db.table("play_history")
+        .select("album_id, played_at")
+        .eq("user_id", user["user_id"])
+        .gte("played_at", min_ts)
+        .lte("played_at", max_ts)
+        .execute()
+    ).data
+    existing_pairs = {(r["album_id"], r["played_at"]) for r in existing_rows}
+
+    new_rows = [
+        {
+            "album_id": p["album_id"],
+            "user_id": user["user_id"],
+            "played_at": p["played_at"],
+            "source": "spotify_sync",
+        }
+        for p in parsed
+        if (p["album_id"], p["played_at"]) not in existing_pairs
+    ]
+
+    if new_rows:
+        db.table("play_history").insert(new_rows).execute()
+
+    return {"synced": len(new_rows)}
+
+
 def _build_album_lookup(album_cache):
-    return {a["spotify_id"]: a for a in album_cache}
+    return {a["service_id"]: a for a in album_cache}
 
 
 def _dedup_album_ids(rows):
@@ -96,7 +146,7 @@ def get_home(
     ).data
     recently_played_ids = {r["album_id"] for r in all_history}
     rediscover_candidates = [
-        a for a in album_cache if a["spotify_id"] not in recently_played_ids
+        a for a in album_cache if a["service_id"] not in recently_played_ids
     ]
     rediscover = random.sample(
         rediscover_candidates, min(20, len(rediscover_candidates))
@@ -127,7 +177,7 @@ def get_home(
     recommended = [
         a
         for a in album_cache
-        if a["spotify_id"] not in played_in_30
+        if a["service_id"] not in played_in_30
         and any(artist in top_artists for artist in a.get("artists", []))
     ][:20]
 

--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -39,18 +39,25 @@ def _get_supabase_cache(db: Client, user_id: str = None):
     return None
 
 
-def _save_supabase_cache(db: Client, albums: list, total: int, user_id: str = None):
+def _save_supabase_cache(
+    db: Client, albums: list, total: int, user_id: str = None, cache_key: str = None
+):
     """Upsert the album list into Supabase library_cache."""
-    cache_key = user_id or "albums"
+    key = cache_key or user_id or "albums"
     db.table("library_cache").upsert(
         {
-            "id": cache_key,
+            "id": key,
             "user_id": user_id,
             "albums": albums,
             "total": total,
             "synced_at": "now()",
         }
     ).execute()
+
+
+def _delete_supabase_cache(db: Client, cache_key: str):
+    """Delete a library_cache row by its id."""
+    db.table("library_cache").delete().eq("id", cache_key).execute()
 
 
 def _normalize_album(item: dict) -> dict:
@@ -104,6 +111,7 @@ def sync_one_page(
         )
 
     user_id = user["user_id"]
+    staging_key = f"{user_id}:staging"
 
     # Fetch one page from Spotify
     result = sp.current_user_saved_albums(limit=50, offset=body.offset)
@@ -111,16 +119,20 @@ def sync_one_page(
     spotify_total = result["total"]
     done = result["next"] is None
 
-    # Compute merged cache: offset=0 clears, offset>0 appends and dedupes
+    # Write to staging cache — main cache is never touched until sync completes
     if body.offset == 0:
         merged = new_albums
     else:
-        existing_row = _get_supabase_cache(db, user_id=user_id)
-        existing_albums = existing_row["albums"] if existing_row else []
-        merged = _dedupe_albums_by_service_id(existing_albums + new_albums)
+        staging_row = _get_supabase_cache(db, user_id=staging_key)
+        staging_albums = staging_row["albums"] if staging_row else []
+        merged = _dedupe_albums_by_service_id(staging_albums + new_albums)
 
-    # Persist
-    _save_supabase_cache(db, merged, len(merged), user_id)
+    _save_supabase_cache(db, merged, len(merged), user_id, cache_key=staging_key)
+
+    # On completion, promote staging to main and delete staging row
+    if done:
+        _save_supabase_cache(db, merged, len(merged), user_id, cache_key=user_id)
+        _delete_supabase_cache(db, staging_key)
 
     return {
         "synced_this_page": len(new_albums),

--- a/backend/tests/test_digest.py
+++ b/backend/tests/test_digest.py
@@ -50,13 +50,13 @@ def test_snapshot_creates_row():
                 "user_id": FAKE_USER_ID,
                 "albums": [
                     {
-                        "spotify_id": "a1",
+                        "service_id": "a1",
                         "name": "Album1",
                         "artists": ["X"],
                         "image_url": None,
                     },
                     {
-                        "spotify_id": "a2",
+                        "service_id": "a2",
                         "name": "Album2",
                         "artists": ["Y"],
                         "image_url": None,
@@ -128,19 +128,19 @@ def test_snapshot_rejects_missing_secret():
 
 ALBUM_CACHE = [
     {
-        "spotify_id": "a1",
+        "service_id": "a1",
         "name": "Album One",
         "artists": ["Artist A"],
         "image_url": "https://img/1.jpg",
     },
     {
-        "spotify_id": "a2",
+        "service_id": "a2",
         "name": "Album Two",
         "artists": ["Artist B"],
         "image_url": "https://img/2.jpg",
     },
     {
-        "spotify_id": "a3",
+        "service_id": "a3",
         "name": "Album Three",
         "artists": ["Artist C"],
         "image_url": "https://img/3.jpg",
@@ -189,8 +189,8 @@ def test_digest_returns_added_and_removed():
         res = client.get("/digest", params={"start": "2026-03-01", "end": "2026-03-08"})
         assert res.status_code == 200
         data = res.json()
-        added_ids = [a["spotify_id"] for a in data["added"]]
-        removed_ids = [a["spotify_id"] for a in data["removed"]]
+        added_ids = [a["service_id"] for a in data["added"]]
+        removed_ids = [a["service_id"] for a in data["removed"]]
         assert "a3" in added_ids
         assert "a2" in removed_ids
         assert "a1" not in added_ids
@@ -233,7 +233,7 @@ def test_digest_returns_listened_with_play_counts():
         data = res.json()
         listened = data["listened"]
         assert len(listened) == 1
-        assert listened[0]["spotify_id"] == "a1"
+        assert listened[0]["service_id"] == "a1"
         assert listened[0]["play_count"] == 3
     finally:
         clear_overrides()
@@ -281,8 +281,8 @@ def test_ensure_snapshot_creates_when_none_exists(mock_date, mock_cache):
     mock_date.today.return_value = date(2026, 3, 15)
     mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
     mock_cache.return_value = [
-        {"spotify_id": "a1", "name": "Album1", "artists": ["X"], "image_url": None},
-        {"spotify_id": "a2", "name": "Album2", "artists": ["Y"], "image_url": None},
+        {"service_id": "a1", "name": "Album1", "artists": ["X"], "image_url": None},
+        {"service_id": "a2", "name": "Album2", "artists": ["Y"], "image_url": None},
     ]
     db = MagicMock()
     # No existing snapshot for today

--- a/backend/tests/test_home.py
+++ b/backend/tests/test_home.py
@@ -85,7 +85,7 @@ def mock_db_with_play_history(rows):
 
 ALBUM_CACHE = [
     {
-        "spotify_id": "album1",
+        "service_id": "album1",
         "name": "Album One",
         "artists": ["Artist A"],
         "image_url": "https://img/1.jpg",
@@ -93,7 +93,7 @@ ALBUM_CACHE = [
         "added_at": "2024-01-15T00:00:00Z",
     },
     {
-        "spotify_id": "album2",
+        "service_id": "album2",
         "name": "Album Two",
         "artists": ["Artist B"],
         "image_url": "https://img/2.jpg",
@@ -101,7 +101,7 @@ ALBUM_CACHE = [
         "added_at": "2024-03-01T00:00:00Z",
     },
     {
-        "spotify_id": "album3",
+        "service_id": "album3",
         "name": "Album Three",
         "artists": ["Artist A"],
         "image_url": "https://img/3.jpg",
@@ -125,7 +125,7 @@ def test_home_returns_today_albums(mock_cache):
         res = client.get("/home", params={"tz": "UTC"})
         assert res.status_code == 200
         data = res.json()
-        today_ids = [a["spotify_id"] for a in data["today"]]
+        today_ids = [a["service_id"] for a in data["today"]]
         assert today_ids == ["album1", "album2"]
     finally:
         clear_overrides()
@@ -157,7 +157,7 @@ def test_home_rediscover_returns_unplayed_albums(mock_cache):
     try:
         res = client.get("/home", params={"tz": "UTC"})
         data = res.json()
-        rediscover_ids = [a["spotify_id"] for a in data["rediscover"]]
+        rediscover_ids = [a["service_id"] for a in data["rediscover"]]
         assert set(rediscover_ids).issubset({"album1", "album2", "album3"})
         assert len(rediscover_ids) <= 20
     finally:
@@ -176,7 +176,7 @@ def test_home_rediscover_excludes_recently_played(mock_cache):
     try:
         res = client.get("/home", params={"tz": "UTC"})
         data = res.json()
-        rediscover_ids = [a["spotify_id"] for a in data["rediscover"]]
+        rediscover_ids = [a["service_id"] for a in data["rediscover"]]
         assert "album1" not in rediscover_ids
     finally:
         clear_overrides()
@@ -196,7 +196,7 @@ def test_home_recommended_by_frequent_artists(mock_cache):
     try:
         res = client.get("/home", params={"tz": "UTC"})
         data = res.json()
-        rec_ids = [a["spotify_id"] for a in data["recommended"]]
+        rec_ids = [a["service_id"] for a in data["recommended"]]
         assert "album3" in rec_ids  # by Artist A but not recently played
         assert "album1" not in rec_ids  # was just played
     finally:
@@ -212,8 +212,122 @@ def test_home_returns_recently_added(mock_cache):
         assert res.status_code == 200
         data = res.json()
         assert "recently_added" in data
-        ids = [a["spotify_id"] for a in data["recently_added"]]
+        ids = [a["service_id"] for a in data["recently_added"]]
         # Should be sorted by added_at descending
         assert ids == ["album2", "album1", "album3"]
+    finally:
+        clear_overrides()
+
+
+def test_sync_history_inserts_new_rows():
+    db = MagicMock()
+    # Mock the select query for existing rows (returns empty — no duplicates)
+    db.table.return_value.select.return_value.eq.return_value.gte.return_value.lte.return_value.execute.return_value = MagicMock(
+        data=[]
+    )
+    db.table.return_value.insert.return_value.execute.return_value = MagicMock(data=[])
+
+    sp = MagicMock()
+    sp.current_user_recently_played.return_value = {
+        "items": [
+            {
+                "track": {"album": {"id": "albumX"}},
+                "played_at": "2024-06-01T10:00:00.000Z",
+            },
+            {
+                "track": {"album": {"id": "albumY"}},
+                "played_at": "2024-06-01T11:00:00.000Z",
+            },
+        ]
+    }
+
+    setup_overrides(db=db, sp=sp)
+    try:
+        res = client.post("/home/history/sync")
+        assert res.status_code == 200
+        data = res.json()
+        assert data["synced"] == 2
+        db.table.return_value.insert.assert_called_once()
+        inserted = db.table.return_value.insert.call_args[0][0]
+        assert len(inserted) == 2
+        assert inserted[0]["source"] == "spotify_sync"
+        assert inserted[0]["album_id"] == "albumX"
+        assert inserted[1]["album_id"] == "albumY"
+    finally:
+        clear_overrides()
+
+
+def test_sync_history_skips_duplicates():
+    db = MagicMock()
+    # Existing row matches one of the items
+    db.table.return_value.select.return_value.eq.return_value.gte.return_value.lte.return_value.execute.return_value = MagicMock(
+        data=[{"album_id": "albumX", "played_at": "2024-06-01T10:00:00.000Z"}]
+    )
+    db.table.return_value.insert.return_value.execute.return_value = MagicMock(data=[])
+
+    sp = MagicMock()
+    sp.current_user_recently_played.return_value = {
+        "items": [
+            {
+                "track": {"album": {"id": "albumX"}},
+                "played_at": "2024-06-01T10:00:00.000Z",
+            },
+            {
+                "track": {"album": {"id": "albumY"}},
+                "played_at": "2024-06-01T11:00:00.000Z",
+            },
+        ]
+    }
+
+    setup_overrides(db=db, sp=sp)
+    try:
+        res = client.post("/home/history/sync")
+        assert res.status_code == 200
+        data = res.json()
+        assert data["synced"] == 1
+        inserted = db.table.return_value.insert.call_args[0][0]
+        assert len(inserted) == 1
+        assert inserted[0]["album_id"] == "albumY"
+    finally:
+        clear_overrides()
+
+
+def test_sync_history_empty_spotify_response():
+    db = MagicMock()
+    sp = MagicMock()
+    sp.current_user_recently_played.return_value = {"items": []}
+
+    setup_overrides(db=db, sp=sp)
+    try:
+        res = client.post("/home/history/sync")
+        assert res.status_code == 200
+        assert res.json() == {"synced": 0}
+    finally:
+        clear_overrides()
+
+
+def test_sync_history_all_duplicates_no_insert():
+    db = MagicMock()
+    db.table.return_value.select.return_value.eq.return_value.gte.return_value.lte.return_value.execute.return_value = MagicMock(
+        data=[{"album_id": "albumX", "played_at": "2024-06-01T10:00:00.000Z"}]
+    )
+
+    sp = MagicMock()
+    sp.current_user_recently_played.return_value = {
+        "items": [
+            {
+                "track": {"album": {"id": "albumX"}},
+                "played_at": "2024-06-01T10:00:00.000Z",
+            },
+        ]
+    }
+
+    setup_overrides(db=db, sp=sp)
+    try:
+        res = client.post("/home/history/sync")
+        assert res.status_code == 200
+        assert res.json() == {"synced": 0}
+        # insert should NOT be called when all rows are duplicates
+        db.table.return_value.insert.assert_not_called()
     finally:
         clear_overrides()

--- a/backend/tests/test_library.py
+++ b/backend/tests/test_library.py
@@ -267,9 +267,153 @@ def test_dedupe_preserves_order_for_unique_ids():
     assert _dedupe_albums_by_service_id(albums) == albums
 
 
-def test_sync_offset_zero_empty_cache_fetches_and_writes():
-    """Cold start: offset=0 fetches one Spotify page and writes it to cache."""
-    db = mock_db_empty()
+def _make_keyed_db(cache_rows: dict[str, dict] = None):
+    """Return a mock Supabase client that stores rows keyed by cache id.
+
+    `cache_rows` maps cache_key -> row dict.  Supports select/eq reads and
+    upsert writes so tests can inspect what was written to each key.
+    """
+    if cache_rows is None:
+        cache_rows = {}
+    store = dict(cache_rows)
+    upsert_log: list[dict] = []
+    delete_log: list[str] = []
+
+    db = MagicMock()
+
+    def _make_table_chain(table_name):
+        table_mock = MagicMock()
+
+        # --- SELECT path ---
+        def _eq(col, val):
+            eq_mock = MagicMock()
+            row = store.get(val)
+            eq_mock.execute.return_value = MagicMock(data=[row] if row else [])
+            return eq_mock
+
+        table_mock.select.return_value.eq = _eq
+
+        # --- UPSERT path ---
+        def _upsert(payload):
+            upsert_log.append(payload)
+            store[payload["id"]] = payload
+            upsert_mock = MagicMock()
+            upsert_mock.execute.return_value = MagicMock(data=[])
+            return upsert_mock
+
+        table_mock.upsert = _upsert
+
+        # --- DELETE path ---
+        def _delete():
+            del_chain = MagicMock()
+
+            def _del_eq(col, val):
+                delete_log.append(val)
+                if val in store:
+                    del store[val]
+                del_eq_mock = MagicMock()
+                del_eq_mock.execute.return_value = MagicMock(data=[])
+                return del_eq_mock
+
+            del_chain.eq = _del_eq
+            return del_chain
+
+        table_mock.delete = _delete
+
+        return table_mock
+
+    db.table = lambda name: _make_table_chain(name)
+    db._store = store
+    db._upsert_log = upsert_log
+    db._delete_log = delete_log
+    return db
+
+
+def test_sync_offset_zero_writes_to_staging_not_main():
+    """offset=0 with done=false writes to staging key only; main is untouched."""
+    db = _make_keyed_db()
+    override_db(db)
+    sp = make_spotify_mock(
+        [
+            {
+                "items": [SAVED_ALBUM] * 50,
+                "total": 120,
+                "next": "https://api.spotify.com/v1/me/albums?offset=50",
+            },
+        ]
+    )
+    override_spotify(sp)
+
+    response = client.post("/library/sync", json={"offset": 0})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["done"] is False
+
+    staging_key = f"{FAKE_USER_ID}:staging"
+    # Staging row was written
+    assert staging_key in db._store
+    assert len(db._store[staging_key]["albums"]) == 50
+    # Main row was NOT written
+    assert FAKE_USER_ID not in db._store
+
+    clear_overrides()
+
+
+def test_sync_offset_nonzero_appends_to_staging():
+    """offset>0 reads staging, appends new page, writes back to staging."""
+    staging_key = f"{FAKE_USER_ID}:staging"
+    existing_staging = {
+        "id": staging_key,
+        "user_id": FAKE_USER_ID,
+        "albums": [
+            {
+                "service_id": "old1",
+                "name": "Old Album",
+                "artists": ["X"],
+                "release_date": "2020",
+                "total_tracks": 10,
+                "image_url": None,
+                "added_at": "2021-01-01T00:00:00Z",
+            }
+        ],
+        "total": 1,
+        "synced_at": "2026-01-01T00:00:00Z",
+    }
+    db = _make_keyed_db({staging_key: existing_staging})
+    override_db(db)
+    sp = make_spotify_mock(
+        [
+            {
+                "items": [SAVED_ALBUM],
+                "total": 2,
+                "next": "https://api.spotify.com/v1/me/albums?offset=100",
+            },
+        ]
+    )
+    override_spotify(sp)
+
+    response = client.post("/library/sync", json={"offset": 50})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["synced_this_page"] == 1
+    assert data["total_in_cache"] == 2
+    assert data["done"] is False
+
+    # Staging updated with both albums
+    staging_ids = [a["service_id"] for a in db._store[staging_key]["albums"]]
+    assert "old1" in staging_ids
+    assert "abc123" in staging_ids
+    # Main still not written
+    assert FAKE_USER_ID not in db._store
+
+    clear_overrides()
+
+
+def test_sync_done_copies_staging_to_main_and_deletes_staging():
+    """When done=true, staging content is promoted to main and staging is deleted."""
+    db = _make_keyed_db()
     override_db(db)
     sp = make_spotify_mock(
         [
@@ -286,28 +430,25 @@ def test_sync_offset_zero_empty_cache_fetches_and_writes():
 
     assert response.status_code == 200
     data = response.json()
-    assert data["synced_this_page"] == 1
-    assert data["total_in_cache"] == 1
-    assert data["spotify_total"] == 1
-    assert data["next_offset"] == 1
     assert data["done"] is True
+    assert data["total_in_cache"] == 1
 
-    # Verify Spotify was called with correct args
-    sp.current_user_saved_albums.assert_called_once_with(limit=50, offset=0)
-
-    # Verify cache was written
-    db.table.assert_any_call("library_cache")
-    db.table.return_value.upsert.assert_called()
+    staging_key = f"{FAKE_USER_ID}:staging"
+    # Main row was written
+    assert FAKE_USER_ID in db._store
+    assert db._store[FAKE_USER_ID]["albums"][0]["service_id"] == "abc123"
+    # Staging row was deleted
+    assert staging_key not in db._store
 
     clear_overrides()
 
 
-def test_sync_offset_nonzero_appends_to_existing_cache():
-    """offset>0 merges the new page into whatever's already in cache."""
-    existing = [
+def test_sync_interrupted_leaves_main_intact():
+    """If sync is interrupted (no done=true), main cache is preserved."""
+    main_albums = [
         {
-            "service_id": "old1",
-            "name": "Old Album",
+            "service_id": "preserved",
+            "name": "Should Survive",
             "artists": ["X"],
             "release_date": "2020",
             "total_tracks": 10,
@@ -315,45 +456,59 @@ def test_sync_offset_nonzero_appends_to_existing_cache():
             "added_at": "2021-01-01T00:00:00Z",
         }
     ]
-    db = mock_db_with_cache(existing, 1)
+    main_row = {
+        "id": FAKE_USER_ID,
+        "user_id": FAKE_USER_ID,
+        "albums": main_albums,
+        "total": 1,
+        "synced_at": "2026-01-01T00:00:00Z",
+    }
+    db = _make_keyed_db({FAKE_USER_ID: main_row})
     override_db(db)
     sp = make_spotify_mock(
         [
-            {"items": [SAVED_ALBUM], "total": 2, "next": None},
+            {
+                "items": [SAVED_ALBUM] * 50,
+                "total": 120,
+                "next": "https://api.spotify.com/v1/me/albums?offset=50",
+            },
         ]
     )
     override_spotify(sp)
 
-    response = client.post("/library/sync", json={"offset": 50})
-
+    # Sync first page (not done)
+    response = client.post("/library/sync", json={"offset": 0})
     assert response.status_code == 200
-    data = response.json()
-    assert data["synced_this_page"] == 1
-    assert data["total_in_cache"] == 2
-    assert data["next_offset"] == 51
+    assert response.json()["done"] is False
 
-    upsert_call = db.table.return_value.upsert.call_args[0][0]
-    service_ids = [a["service_id"] for a in upsert_call["albums"]]
-    assert "old1" in service_ids
-    assert "abc123" in service_ids
+    # Main cache is still the old data
+    assert db._store[FAKE_USER_ID]["albums"] == main_albums
+    assert db._store[FAKE_USER_ID]["albums"][0]["service_id"] == "preserved"
 
     clear_overrides()
 
 
 def test_sync_offset_nonzero_dedupes_by_service_id():
     """Retried page or racing tabs produce duplicate items; dedupe keeps one."""
-    existing = [
-        {
-            "service_id": "abc123",  # same ID as SAVED_ALBUM
-            "name": "Stale name",
-            "artists": ["X"],
-            "release_date": "2020",
-            "total_tracks": 10,
-            "image_url": None,
-            "added_at": "2021-01-01T00:00:00Z",
-        }
-    ]
-    db = mock_db_with_cache(existing, 1)
+    staging_key = f"{FAKE_USER_ID}:staging"
+    existing_staging = {
+        "id": staging_key,
+        "user_id": FAKE_USER_ID,
+        "albums": [
+            {
+                "service_id": "abc123",  # same ID as SAVED_ALBUM
+                "name": "Stale name",
+                "artists": ["X"],
+                "release_date": "2020",
+                "total_tracks": 10,
+                "image_url": None,
+                "added_at": "2021-01-01T00:00:00Z",
+            }
+        ],
+        "total": 1,
+        "synced_at": "2026-01-01T00:00:00Z",
+    }
+    db = _make_keyed_db({staging_key: existing_staging})
     override_db(db)
     sp = make_spotify_mock(
         [
@@ -368,28 +523,34 @@ def test_sync_offset_nonzero_dedupes_by_service_id():
     data = response.json()
     assert data["total_in_cache"] == 1  # deduped, not 2
 
-    upsert_call = db.table.return_value.upsert.call_args[0][0]
-    assert len(upsert_call["albums"]) == 1
-    # Last-wins: the new album data should be present
-    assert upsert_call["albums"][0]["name"] == "Dummy Album"
+    # Main row should have the deduped result (done=true)
+    assert len(db._store[FAKE_USER_ID]["albums"]) == 1
+    assert db._store[FAKE_USER_ID]["albums"][0]["name"] == "Dummy Album"
 
     clear_overrides()
 
 
 def test_sync_offset_zero_clears_existing_cache():
-    """A fresh sync (offset=0) must wipe stale data before writing the new first page."""
-    stale = [
-        {
-            "service_id": "deleted_album",
-            "name": "User deleted this",
-            "artists": ["X"],
-            "release_date": "2020",
-            "total_tracks": 10,
-            "image_url": None,
-            "added_at": "2021-01-01T00:00:00Z",
-        }
-    ]
-    db = mock_db_with_cache(stale, 1)
+    """A fresh sync (offset=0) must wipe stale staging data before writing the new first page."""
+    staging_key = f"{FAKE_USER_ID}:staging"
+    stale_staging = {
+        "id": staging_key,
+        "user_id": FAKE_USER_ID,
+        "albums": [
+            {
+                "service_id": "deleted_album",
+                "name": "User deleted this",
+                "artists": ["X"],
+                "release_date": "2020",
+                "total_tracks": 10,
+                "image_url": None,
+                "added_at": "2021-01-01T00:00:00Z",
+            }
+        ],
+        "total": 1,
+        "synced_at": "2026-01-01T00:00:00Z",
+    }
+    db = _make_keyed_db({staging_key: stale_staging})
     override_db(db)
     sp = make_spotify_mock(
         [
@@ -404,8 +565,8 @@ def test_sync_offset_zero_clears_existing_cache():
     data = response.json()
     assert data["total_in_cache"] == 1
 
-    upsert_call = db.table.return_value.upsert.call_args[0][0]
-    service_ids = [a["service_id"] for a in upsert_call["albums"]]
+    # Main row has only the new album (done=true promoted staging)
+    service_ids = [a["service_id"] for a in db._store[FAKE_USER_ID]["albums"]]
     assert "deleted_album" not in service_ids
     assert "abc123" in service_ids
 
@@ -414,7 +575,7 @@ def test_sync_offset_zero_clears_existing_cache():
 
 def test_sync_returns_done_false_when_more_pages_remain():
     """Spotify has a `next` URL -> done is False and next_offset points to page 2."""
-    db = mock_db_empty()
+    db = _make_keyed_db()
     override_db(db)
     sp = make_spotify_mock(
         [
@@ -456,7 +617,7 @@ def test_sync_returns_401_when_not_authenticated():
 
 def test_sync_rejects_negative_offset():
     """Negative offset is a client bug -- reject with 400."""
-    db = mock_db_empty()
+    db = _make_keyed_db()
     override_db(db)
     sp = make_spotify_mock([{"items": [], "total": 0, "next": None}])
     override_spotify(sp)
@@ -470,7 +631,7 @@ def test_sync_rejects_negative_offset():
 
 def test_sync_rejects_non_multiple_of_50_offset():
     """Offset must be a multiple of 50 (Spotify's page size)."""
-    db = mock_db_empty()
+    db = _make_keyed_db()
     override_db(db)
     sp = make_spotify_mock([{"items": [], "total": 0, "next": None}])
     override_spotify(sp)
@@ -483,8 +644,8 @@ def test_sync_rejects_non_multiple_of_50_offset():
 
 
 def test_sync_updates_last_synced_timestamp():
-    """Every successful sync writes synced_at = now() to the cache row."""
-    db = mock_db_empty()
+    """Completed sync writes synced_at = now() to the main cache row."""
+    db = _make_keyed_db()
     override_db(db)
     sp = make_spotify_mock([{"items": [SAVED_ALBUM], "total": 1, "next": None}])
     override_spotify(sp)
@@ -492,17 +653,17 @@ def test_sync_updates_last_synced_timestamp():
     response = client.post("/library/sync", json={"offset": 0})
 
     assert response.status_code == 200
-    upsert_call = db.table.return_value.upsert.call_args[0][0]
-    assert "synced_at" in upsert_call
-    # _save_supabase_cache passes the literal string "now()" to let Postgres resolve it
-    assert upsert_call["synced_at"] == "now()"
+    # Main row should have synced_at (done=true promotes staging to main)
+    main_row = db._store[FAKE_USER_ID]
+    assert "synced_at" in main_row
+    assert main_row["synced_at"] == "now()"
 
     clear_overrides()
 
 
 def test_sync_propagates_spotify_errors():
     """If Spotify raises, the endpoint returns a 5xx response to the client."""
-    db = mock_db_empty()
+    db = _make_keyed_db()
     override_db(db)
     sp = MagicMock()
     sp.current_user_saved_albums.side_effect = Exception("Spotify API down")
@@ -520,7 +681,7 @@ def test_sync_propagates_spotify_errors():
 
 def test_sync_handles_empty_library():
     """A user with zero saved albums gets done=True immediately."""
-    db = mock_db_empty()
+    db = _make_keyed_db()
     override_db(db)
     sp = make_spotify_mock(
         [

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,7 @@
     { "source": "/api/(.*)", "destination": "/api/index" },
     { "source": "/((?!api/).*)", "destination": "/index.html" }
   ],
+  "crons": [{ "path": "/api/digest/snapshot", "schedule": "0 6 * * *" }],
   "functions": {
     "api/index.py": {
       "runtime": "@vercel/python@4.3.0",


### PR DESCRIPTION
## Summary

- **#18 Library sync data loss**: Sync now writes to a staging cache key during page-by-page fetch. Main cache only updated on completion — interrupted syncs preserve existing data.
- **#19 Digest always empty**: Added daily Vercel cron (6 AM UTC) for `POST /digest/snapshot` so historical snapshots accumulate automatically.
- **#20 Home page blank**: New `POST /home/history/sync` endpoint backfills `play_history` from Spotify's recently-played API, so home page reflects all listening activity.
- **Bonus**: Fixed `spotify_id` → `service_id` field name mismatch in digest and home routers to match library cache schema.

## Test plan

- [x] 48 tests passing across `test_library.py`, `test_home.py`, `test_digest.py`
- [ ] Verify library sync survives tab close mid-sync (manual)
- [ ] Verify digest page shows data after 2+ days with cron running
- [ ] Verify home page populates after calling `/home/history/sync`

🤖 Generated with [Claude Code](https://claude.com/claude-code)