### PR TITLE
Set up staging preview with real Spotify auth

### DIFF
--- a/backend/auth_middleware.py
+++ b/backend/auth_middleware.py
@@ -28,14 +28,19 @@ _preview_session: dict | None = None
 
 
 def _is_preview_env() -> bool:
-    """True iff we are running on a Vercel preview deploy.
+    """True iff we are running on a Vercel preview deploy with auth bypass active.
 
     Relies solely on the Vercel-injected VERCEL_ENV system variable,
     which Vercel sets to 'production' / 'preview' / 'development'
     based on deploy type. Cannot be overridden from the project env
     var UI for the production scope.
+
+    When PREVIEW_REAL_AUTH=true, the bypass is disabled so preview
+    deploys use real Supabase/Spotify authentication.
     """
-    return os.getenv("VERCEL_ENV") == "preview"
+    if os.getenv("VERCEL_ENV") != "preview":
+        return False
+    return os.getenv("PREVIEW_REAL_AUTH") != "true"
 
 
 def _get_preview_session() -> dict:

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,7 +8,7 @@ from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
 
-from routers import apple_music_auth, auth, digest, home, library, metadata, playback
+from routers import apple_music_auth, auth, auth_proxy, digest, home, library, metadata, playback
 
 load_dotenv()
 
@@ -47,6 +47,7 @@ app.add_middleware(
 )
 
 app.include_router(auth.router)
+app.include_router(auth_proxy.router)
 app.include_router(apple_music_auth.router)
 app.include_router(home.router)
 app.include_router(library.router)

--- a/backend/routers/auth_proxy.py
+++ b/backend/routers/auth_proxy.py
@@ -1,0 +1,261 @@
+"""Spotify OAuth callback proxy for Vercel preview deploys.
+
+Allows preview deploys (with dynamic URLs) to use real Spotify authentication
+by routing OAuth through the prod domain's stable redirect URI.
+"""
+
+import base64
+import hashlib
+import hmac as hmac_mod
+import json
+import os
+import re
+import secrets
+import time
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
+
+import requests
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import RedirectResponse
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+from db import get_service_db
+
+limiter = Limiter(key_func=get_remote_address)
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+# Spotify scopes needed for Bummer
+_SPOTIFY_SCOPES = (
+    "user-library-read "
+    "user-read-playback-state "
+    "user-modify-playback-state "
+    "user-read-currently-playing"
+)
+
+# Only allow Vercel preview deploy origins for this project
+_ORIGIN_RE = re.compile(r"^https://[a-z0-9-]+-toofanians-projects\.vercel\.app$")
+
+
+def _get_proxy_config() -> tuple[str, str]:
+    """Return (secret, redirect_uri) or raise 501 if not configured."""
+    secret = os.getenv("SPOTIFY_PROXY_SECRET", "")
+    redirect_uri = os.getenv("SPOTIFY_PROXY_REDIRECT_URI", "")
+    if not secret or not redirect_uri:
+        raise HTTPException(status_code=501, detail="Spotify proxy not configured")
+    return secret, redirect_uri
+
+
+def _validate_origin(origin: str) -> None:
+    """Raise 400 if origin doesn't match the allowed pattern."""
+    if not _ORIGIN_RE.match(origin):
+        raise HTTPException(status_code=400, detail="Invalid origin")
+
+
+def _b64url_encode(data: bytes) -> str:
+    """Base64url encode without padding."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def _b64url_decode(s: str) -> bytes:
+    """Base64url decode with padding restoration."""
+    padding = 4 - len(s) % 4
+    if padding != 4:
+        s += "=" * padding
+    return base64.urlsafe_b64decode(s)
+
+
+def _sign_state(payload_dict: dict, secret: str) -> str:
+    """JSON-serialize, HMAC-sign, and encode state as base64url.sig."""
+    payload_json = json.dumps(payload_dict, separators=(",", ":"), sort_keys=True)
+    payload_b64 = _b64url_encode(payload_json.encode())
+    sig = hmac_mod.new(secret.encode(), payload_json.encode(), hashlib.sha256).hexdigest()
+    return f"{payload_b64}.{sig}"
+
+
+def _verify_state(state: str, secret: str) -> dict:
+    """Decode and verify a signed state string. Returns the payload dict."""
+    parts = state.split(".", 1)
+    if len(parts) != 2:
+        raise HTTPException(status_code=400, detail="Malformed state")
+
+    payload_b64, sig_hex = parts
+    try:
+        payload_json = _b64url_decode(payload_b64).decode()
+        payload = json.loads(payload_json)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Malformed state payload")
+
+    # Recompute HMAC and compare constant-time
+    expected_sig = hmac_mod.new(
+        secret.encode(), payload_json.encode(), hashlib.sha256
+    ).hexdigest()
+    if not hmac_mod.compare_digest(sig_hex, expected_sig):
+        raise HTTPException(status_code=400, detail="Invalid state signature")
+
+    # Check timestamp freshness (10 min window)
+    ts = payload.get("ts", 0)
+    if abs(time.time() - ts) > 600:
+        raise HTTPException(status_code=400, detail="State expired")
+
+    # Validate origin in payload
+    origin = payload.get("origin", "")
+    _validate_origin(origin)
+
+    return payload
+
+
+def verify_supabase_jwt(token: str) -> str:
+    """Verify a Supabase JWT and return the user_id (sub claim).
+
+    Reuses the JWKS client from auth_middleware.
+    """
+    import jwt as pyjwt
+    from auth_middleware import _get_jwks_client
+
+    try:
+        jwks_client = _get_jwks_client()
+        signing_key = jwks_client.get_signing_key_from_jwt(token)
+        payload = pyjwt.decode(
+            token,
+            signing_key.key,
+            algorithms=["ES256", "HS256"],
+            audience="authenticated",
+        )
+    except pyjwt.ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Token expired")
+    except Exception as e:
+        raise HTTPException(status_code=401, detail=f"Invalid token: {e}")
+
+    user_id = payload.get("sub")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Token missing subject")
+    return user_id
+
+
+# ---------------------------------------------------------------------------
+# Endpoint 1: GET /auth/preview-login
+# ---------------------------------------------------------------------------
+
+
+@router.get("/preview-login")
+@limiter.limit("5/minute")
+async def preview_login(
+    request: Request,
+    origin: str = Query(...),
+    client_id: str = Query(...),
+    supabase_token: str = Query(...),
+):
+    """Initiate Spotify OAuth for a preview deploy.
+
+    Generates PKCE + signed state and redirects to Spotify's authorize endpoint.
+    """
+    secret, redirect_uri = _get_proxy_config()
+
+    _validate_origin(origin)
+
+    # Verify the Supabase JWT to get the user_id
+    try:
+        user_id = verify_supabase_jwt(supabase_token)
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid Supabase token")
+
+    # Generate PKCE
+    verifier_bytes = secrets.token_bytes(64)
+    verifier = _b64url_encode(verifier_bytes)
+    challenge = _b64url_encode(hashlib.sha256(verifier.encode()).digest())
+
+    # Build signed state
+    state_payload = {
+        "origin": origin,
+        "user_id": user_id,
+        "client_id": client_id,
+        "verifier": verifier,
+        "ts": int(time.time()),
+    }
+    state = _sign_state(state_payload, secret)
+
+    # Build Spotify authorize URL
+    params = {
+        "client_id": client_id,
+        "response_type": "code",
+        "redirect_uri": redirect_uri,
+        "scope": _SPOTIFY_SCOPES,
+        "code_challenge_method": "S256",
+        "code_challenge": challenge,
+        "state": state,
+    }
+    spotify_url = f"https://accounts.spotify.com/authorize?{urlencode(params)}"
+    return RedirectResponse(url=spotify_url, status_code=302)
+
+
+# ---------------------------------------------------------------------------
+# Endpoint 2: GET /auth/callback-proxy
+# ---------------------------------------------------------------------------
+
+
+@router.get("/callback-proxy")
+@limiter.limit("10/minute")
+async def callback_proxy(
+    request: Request,
+    code: str | None = Query(default=None),
+    state: str = Query(...),
+    error: str | None = Query(default=None),
+):
+    """Receive Spotify's OAuth callback, exchange code for tokens, redirect to preview."""
+    secret, redirect_uri = _get_proxy_config()
+
+    # Attempt to extract origin from state for error redirects
+    # (best effort — if state is totally broken we return 400)
+    payload = _verify_state(state, secret)
+    origin = payload["origin"]
+
+    # Handle Spotify error
+    if error:
+        return RedirectResponse(
+            url=f"{origin}/?spotify_error={error}",
+            status_code=302,
+        )
+
+    if not code:
+        raise HTTPException(status_code=400, detail="Missing authorization code")
+
+    # Exchange code for tokens
+    token_response = requests.post(
+        "https://accounts.spotify.com/api/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "client_id": payload["client_id"],
+            "code_verifier": payload["verifier"],
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        timeout=10,
+    )
+    token_response.raise_for_status()
+    tokens = token_response.json()
+
+    # Store tokens in Supabase
+    now = datetime.now(timezone.utc)
+    db = get_service_db()
+    db.table("music_tokens").upsert(
+        {
+            "user_id": payload["user_id"],
+            "access_token": tokens["access_token"],
+            "refresh_token": tokens["refresh_token"],
+            "expires_at": (now + timedelta(seconds=tokens["expires_in"])).isoformat(),
+            "client_id": payload["client_id"],
+            "updated_at": now.isoformat(),
+        }
+    ).execute()
+
+    # Redirect back to preview
+    return RedirectResponse(
+        url=f"{origin}/auth/spotify/callback?proxy_success=true",
+        status_code=302,
+    )

--- a/backend/spotify_client.py
+++ b/backend/spotify_client.py
@@ -69,7 +69,7 @@ async def get_user_spotify(
     # Spotify API will fail at the call site, which is the expected
     # limitation of the preview auth bypass.
     import os
-    if os.getenv("VERCEL_ENV") == "preview":
+    if os.getenv("VERCEL_ENV") == "preview" and os.getenv("PREVIEW_REAL_AUTH") != "true":
         return spotipy.Spotify(auth="PREVIEW_FAKE_ACCESS")
 
     db = get_service_db()

--- a/backend/tests/test_auth_proxy.py
+++ b/backend/tests/test_auth_proxy.py
@@ -1,0 +1,258 @@
+"""Tests for Spotify OAuth callback proxy endpoints (preview-login & callback-proxy)."""
+
+import base64
+import hashlib
+import hmac as hmac_mod
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app, follow_redirects=False)
+
+PROXY_SECRET = "a" * 64  # 32-byte hex string for test HMAC
+PROXY_REDIRECT_URI = "https://thedeathofshuffle.com/api/auth/callback-proxy"
+VALID_ORIGIN = "https://bummer-abc123-toofanians-projects.vercel.app"
+TEST_CLIENT_ID = "test-spotify-client-id"
+TEST_USER_ID = "test-user-uuid-1234"
+TEST_SUPABASE_TOKEN = "fake-supabase-jwt"
+
+
+def _env_vars(**overrides):
+    """Return a dict of env vars for patching, with sensible defaults."""
+    env = {
+        "SPOTIFY_PROXY_SECRET": PROXY_SECRET,
+        "SPOTIFY_PROXY_REDIRECT_URI": PROXY_REDIRECT_URI,
+    }
+    env.update(overrides)
+    return env
+
+
+def _mock_jwt_verify(monkeypatch=None):
+    """Patch JWT verification to accept any token and return TEST_USER_ID."""
+    # We patch at the module level where the function is used
+    pass  # Handled per-test via patch decorators
+
+
+def _build_signed_state(payload_dict, secret=PROXY_SECRET):
+    """Build a signed state string the same way the endpoint does."""
+    payload_json = json.dumps(payload_dict, separators=(",", ":"), sort_keys=True)
+    payload_b64 = base64.urlsafe_b64encode(payload_json.encode()).rstrip(b"=").decode()
+    sig = hmac_mod.new(secret.encode(), payload_json.encode(), hashlib.sha256).hexdigest()
+    return f"{payload_b64}.{sig}"
+
+
+def _valid_state_payload(**overrides):
+    """Return a valid state payload dict."""
+    payload = {
+        "origin": VALID_ORIGIN,
+        "user_id": TEST_USER_ID,
+        "client_id": TEST_CLIENT_ID,
+        "verifier": "dGVzdHZlcmlmaWVy",  # base64url of "testverifier"
+        "ts": int(time.time()),
+    }
+    payload.update(overrides)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Endpoint 1: GET /auth/preview-login
+# ---------------------------------------------------------------------------
+
+
+class TestPreviewLogin:
+    """Tests for GET /auth/preview-login."""
+
+    @patch.dict("os.environ", _env_vars(), clear=False)
+    @patch("routers.auth.limiter")
+    def test_preview_login_redirects_to_spotify(self, mock_limiter):
+        """Valid params should produce a 302 redirect to accounts.spotify.com/authorize."""
+        mock_limiter.reset.return_value = None
+
+        # Mock JWT verification to accept our test token
+        with patch("routers.auth_proxy.verify_supabase_jwt", return_value=TEST_USER_ID):
+            response = client.get(
+                "/auth/preview-login",
+                params={
+                    "origin": VALID_ORIGIN,
+                    "client_id": TEST_CLIENT_ID,
+                    "supabase_token": TEST_SUPABASE_TOKEN,
+                },
+            )
+
+        assert response.status_code == 302
+        location = response.headers["location"]
+        assert location.startswith("https://accounts.spotify.com/authorize")
+        assert "response_type=code" in location
+        assert "code_challenge_method=S256" in location
+        assert f"client_id={TEST_CLIENT_ID}" in location
+        assert "state=" in location
+
+    @patch.dict("os.environ", _env_vars(), clear=False)
+    def test_preview_login_rejects_invalid_origin(self):
+        """Origin not matching the vercel preview pattern should return 400."""
+        with patch("routers.auth_proxy.verify_supabase_jwt", return_value=TEST_USER_ID):
+            response = client.get(
+                "/auth/preview-login",
+                params={
+                    "origin": "https://evil.example.com",
+                    "client_id": TEST_CLIENT_ID,
+                    "supabase_token": TEST_SUPABASE_TOKEN,
+                },
+            )
+        assert response.status_code == 400
+
+    @patch.dict("os.environ", _env_vars(), clear=False)
+    def test_preview_login_rejects_missing_params(self):
+        """Missing required query params should return 422."""
+        # Missing all params
+        response = client.get("/auth/preview-login")
+        assert response.status_code == 422
+
+        # Missing client_id
+        response = client.get(
+            "/auth/preview-login",
+            params={"origin": VALID_ORIGIN, "supabase_token": TEST_SUPABASE_TOKEN},
+        )
+        assert response.status_code == 422
+
+    @patch.dict("os.environ", _env_vars(), clear=False)
+    def test_preview_login_rejects_invalid_supabase_token(self):
+        """Bad JWT should return 401."""
+        with patch(
+            "routers.auth_proxy.verify_supabase_jwt",
+            side_effect=Exception("Invalid token"),
+        ):
+            response = client.get(
+                "/auth/preview-login",
+                params={
+                    "origin": VALID_ORIGIN,
+                    "client_id": TEST_CLIENT_ID,
+                    "supabase_token": "bad-token",
+                },
+            )
+        assert response.status_code == 401
+
+    def test_preview_login_returns_501_when_not_configured(self):
+        """Missing SPOTIFY_PROXY_SECRET env var should return 501."""
+        # Ensure env vars are NOT set
+        with patch.dict(
+            "os.environ",
+            {"SPOTIFY_PROXY_SECRET": "", "SPOTIFY_PROXY_REDIRECT_URI": ""},
+            clear=False,
+        ):
+            response = client.get(
+                "/auth/preview-login",
+                params={
+                    "origin": VALID_ORIGIN,
+                    "client_id": TEST_CLIENT_ID,
+                    "supabase_token": TEST_SUPABASE_TOKEN,
+                },
+            )
+        assert response.status_code == 501
+
+
+# ---------------------------------------------------------------------------
+# Endpoint 2: GET /auth/callback-proxy
+# ---------------------------------------------------------------------------
+
+
+class TestCallbackProxy:
+    """Tests for GET /auth/callback-proxy."""
+
+    @patch.dict("os.environ", _env_vars(), clear=False)
+    def test_callback_proxy_exchanges_code_and_redirects(self):
+        """Valid state + code should exchange tokens, store them, and redirect."""
+        state_payload = _valid_state_payload()
+        state = _build_signed_state(state_payload)
+
+        mock_token_response = MagicMock()
+        mock_token_response.status_code = 200
+        mock_token_response.json.return_value = {
+            "access_token": "sp-access-token",
+            "refresh_token": "sp-refresh-token",
+            "expires_in": 3600,
+        }
+        mock_token_response.raise_for_status = MagicMock()
+
+        mock_db = MagicMock()
+        mock_db.table.return_value.upsert.return_value.execute.return_value = MagicMock()
+
+        with (
+            patch("routers.auth_proxy.requests.post", return_value=mock_token_response),
+            patch("routers.auth_proxy.get_service_db", return_value=mock_db),
+        ):
+            response = client.get(
+                "/auth/callback-proxy",
+                params={"code": "auth-code-123", "state": state},
+            )
+
+        assert response.status_code == 302
+        location = response.headers["location"]
+        assert location.startswith(VALID_ORIGIN)
+        assert "proxy_success=true" in location
+
+        # Verify token was stored
+        mock_db.table.assert_called_with("music_tokens")
+        upsert_arg = mock_db.table.return_value.upsert.call_args[0][0]
+        assert upsert_arg["user_id"] == TEST_USER_ID
+        assert upsert_arg["access_token"] == "sp-access-token"
+        assert upsert_arg["refresh_token"] == "sp-refresh-token"
+        assert upsert_arg["client_id"] == TEST_CLIENT_ID
+
+    @patch.dict("os.environ", _env_vars(), clear=False)
+    def test_callback_proxy_rejects_tampered_state(self):
+        """Modified HMAC should return 400."""
+        state_payload = _valid_state_payload()
+        state = _build_signed_state(state_payload)
+        # Tamper with the signature
+        parts = state.split(".")
+        tampered_state = parts[0] + "." + "0" * 64
+
+        response = client.get(
+            "/auth/callback-proxy",
+            params={"code": "auth-code-123", "state": tampered_state},
+        )
+        assert response.status_code == 400
+
+    @patch.dict("os.environ", _env_vars(), clear=False)
+    def test_callback_proxy_rejects_stale_state(self):
+        """Timestamp older than 10 minutes should return 400."""
+        state_payload = _valid_state_payload(ts=int(time.time()) - 700)  # 11+ min ago
+        state = _build_signed_state(state_payload)
+
+        response = client.get(
+            "/auth/callback-proxy",
+            params={"code": "auth-code-123", "state": state},
+        )
+        assert response.status_code == 400
+
+    @patch.dict("os.environ", _env_vars(), clear=False)
+    def test_callback_proxy_rejects_invalid_origin_in_state(self):
+        """Origin in state not matching pattern should return 400."""
+        state_payload = _valid_state_payload(origin="https://evil.example.com")
+        state = _build_signed_state(state_payload)
+
+        response = client.get(
+            "/auth/callback-proxy",
+            params={"code": "auth-code-123", "state": state},
+        )
+        assert response.status_code == 400
+
+    @patch.dict("os.environ", _env_vars(), clear=False)
+    def test_callback_proxy_handles_spotify_error(self):
+        """When Spotify redirects with error param, redirect to origin with error."""
+        state_payload = _valid_state_payload()
+        state = _build_signed_state(state_payload)
+
+        response = client.get(
+            "/auth/callback-proxy",
+            params={"error": "access_denied", "state": state},
+        )
+        assert response.status_code == 302
+        location = response.headers["location"]
+        assert VALID_ORIGIN in location
+        assert "spotify_error=access_denied" in location

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -144,8 +144,8 @@ export default function App() {
         } catch { /* storage full or unavailable */ }
       }
 
-      // 3. Drive the sync loop — skip in preview (no real Spotify tokens).
-      if (!IS_PREVIEW) {
+      // 3. Drive the sync loop — skip in preview (no real Spotify tokens) unless real Spotify is enabled.
+      if (!IS_PREVIEW || previewRealSpotify) {
         setSyncing(true)
         let offset = 0
         let progress = null
@@ -582,9 +582,10 @@ export default function App() {
   // Auth gate
   const isSpotifyCallback = window.location.pathname === '/auth/spotify/callback'
   const hasLocalClientId = !!localStorage.getItem('spotify_client_id')
+  const previewRealSpotify = IS_PREVIEW && import.meta.env.VITE_PREVIEW_REAL_SPOTIFY === 'true'
   // Onboarding check state: 'idle' | 'checking' | 'needs_onboarding' | 'reconnecting' | 'ready'
   const [onboardingCheckState, setOnboardingCheckState] = useState(() => {
-    if (IS_PREVIEW) return 'ready' // Preview deploys skip onboarding entirely
+    if (IS_PREVIEW && !previewRealSpotify) return 'ready' // Preview deploys skip onboarding (unless real Spotify is enabled)
     if (!session) return 'idle'
     if (isSpotifyCallback) return 'needs_onboarding' // OnboardingWizard handles callback
     if (hasLocalClientId) return 'ready'
@@ -593,7 +594,7 @@ export default function App() {
 
   // Transition from 'idle' once session arrives
   useEffect(() => {
-    if (IS_PREVIEW) return
+    if (IS_PREVIEW && !previewRealSpotify) return
     if (onboardingCheckState !== 'idle' || !session) return
     if (isSpotifyCallback) {
       setOnboardingCheckState('needs_onboarding')
@@ -605,7 +606,7 @@ export default function App() {
   }, [onboardingCheckState, session, isSpotifyCallback, hasLocalClientId])
 
   useEffect(() => {
-    if (IS_PREVIEW) return
+    if (IS_PREVIEW && !previewRealSpotify) return
     if (onboardingCheckState !== 'checking' || !session) return
     let cancelled = false
     ;(async () => {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -608,6 +608,12 @@ export default function App() {
   useEffect(() => {
     if (IS_PREVIEW && !previewRealSpotify) return
     if (onboardingCheckState !== 'checking' || !session) return
+    // On preview with real Spotify, skip credential check — force fresh onboarding
+    // (the preview user's seeded music_tokens row has fake credentials)
+    if (previewRealSpotify) {
+      setOnboardingCheckState('needs_onboarding')
+      return
+    }
     let cancelled = false
     ;(async () => {
       try {

--- a/frontend/src/components/OnboardingWizard.jsx
+++ b/frontend/src/components/OnboardingWizard.jsx
@@ -70,7 +70,7 @@ function AppleMusicSetup({ onBack }) {
 
 function SpotifySetup({ session, onComplete }) {
   const { initiateLogin, handleCallback, accessToken } = useSpotifyAuth()
-  const [clientId, setClientId] = useState('')
+  const [clientId, setClientId] = useState(() => import.meta.env.VITE_SPOTIFY_CLIENT_ID ?? '')
   const [loading, setLoading] = useState(() => {
     const params = new URLSearchParams(window.location.search)
     return !!params.get('code') || params.get('proxy_success') === 'true'
@@ -205,11 +205,6 @@ function SpotifySetup({ session, onComplete }) {
           </div>
           {copyStatus && (
             <p className="mt-1 text-xs text-gray-500">{copyStatus}</p>
-          )}
-          {IS_PREVIEW && (
-            <p className="mt-2 text-xs text-yellow-400">
-              For preview testing, also add: <code className="bg-gray-900 px-1 rounded">{PROXY_REDIRECT_URI}</code>
-            </p>
           )}
         </li>
         <li>Check <span className="text-white">Web API</span> and <span className="text-white">Web Playback SDK</span> under APIs used.</li>

--- a/frontend/src/components/OnboardingWizard.jsx
+++ b/frontend/src/components/OnboardingWizard.jsx
@@ -70,7 +70,7 @@ function AppleMusicSetup({ onBack }) {
 
 function SpotifySetup({ session, onComplete }) {
   const { initiateLogin, handleCallback, accessToken } = useSpotifyAuth()
-  const [clientId, setClientId] = useState(() => import.meta.env.VITE_SPOTIFY_CLIENT_ID ?? '')
+  const [clientId, setClientId] = useState('')
   const [loading, setLoading] = useState(() => {
     const params = new URLSearchParams(window.location.search)
     return !!params.get('code') || params.get('proxy_success') === 'true'
@@ -87,6 +87,25 @@ function SpotifySetup({ session, onComplete }) {
     }
     setTimeout(() => setCopyStatus(''), 2000)
   }
+
+  // Pre-fill client ID from server if user has connected Spotify before
+  useEffect(() => {
+    if (!session) return
+    let cancelled = false
+    ;(async () => {
+      try {
+        const res = await fetch(`${API}/auth/spotify-status`, {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        })
+        if (!res.ok || cancelled) return
+        const data = await res.json()
+        if (data.client_id && !cancelled) {
+          setClientId(data.client_id)
+        }
+      } catch { /* ignore — user can type it manually */ }
+    })()
+    return () => { cancelled = true }
+  }, [session])
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)

--- a/frontend/src/components/OnboardingWizard.jsx
+++ b/frontend/src/components/OnboardingWizard.jsx
@@ -1,8 +1,11 @@
 import { useState, useEffect } from 'react'
 import { useSpotifyAuth } from '../hooks/useSpotifyAuth'
+import { IS_PREVIEW } from '../previewMode'
 
 const API = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:8000'
 const REDIRECT_URI = import.meta.env.VITE_SPOTIFY_REDIRECT_URI ?? 'http://localhost:5173/auth/spotify/callback'
+const PROD_ORIGIN = import.meta.env.VITE_PROD_ORIGIN ?? 'https://thedeathofshuffle.com'
+const PROXY_REDIRECT_URI = `${PROD_ORIGIN}/api/auth/callback-proxy`
 
 function ServiceSelector({ onSelect }) {
   return (
@@ -70,7 +73,7 @@ function SpotifySetup({ session, onComplete }) {
   const [clientId, setClientId] = useState('')
   const [loading, setLoading] = useState(() => {
     const params = new URLSearchParams(window.location.search)
-    return !!params.get('code')
+    return !!params.get('code') || params.get('proxy_success') === 'true'
   })
   const [error, setError] = useState('')
   const [copyStatus, setCopyStatus] = useState('')
@@ -87,6 +90,14 @@ function SpotifySetup({ session, onComplete }) {
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
+
+    // Preview proxy callback: prod already stored tokens, just clean up and complete
+    if (params.get('proxy_success') === 'true') {
+      window.history.replaceState({}, '', '/')
+      onComplete()
+      return
+    }
+
     const code = params.get('code')
     if (!code) return
 
@@ -135,7 +146,7 @@ function SpotifySetup({ session, onComplete }) {
     localStorage.setItem('music_service_type', 'spotify')
     setLoading(true)
     try {
-      await initiateLogin()
+      await initiateLogin(session?.access_token)
     } catch (err) {
       setError(err.message)
       setLoading(false)
@@ -194,6 +205,11 @@ function SpotifySetup({ session, onComplete }) {
           </div>
           {copyStatus && (
             <p className="mt-1 text-xs text-gray-500">{copyStatus}</p>
+          )}
+          {IS_PREVIEW && (
+            <p className="mt-2 text-xs text-yellow-400">
+              For preview testing, also add: <code className="bg-gray-900 px-1 rounded">{PROXY_REDIRECT_URI}</code>
+            </p>
           )}
         </li>
         <li>Check <span className="text-white">Web API</span> and <span className="text-white">Web Playback SDK</span> under APIs used.</li>

--- a/frontend/src/components/OnboardingWizard.test.jsx
+++ b/frontend/src/components/OnboardingWizard.test.jsx
@@ -39,6 +39,14 @@ describe('OnboardingWizard', () => {
     localStorage.clear()
     vi.clearAllMocks()
     window.history.replaceState({}, '', '/')
+    // Default fetch mock: handle /auth/spotify-status (client ID pre-fill)
+    // and any other fetches. Tests that need specific fetch behavior override this.
+    fetch.mockImplementation((url) => {
+      if (typeof url === 'string' && url.includes('/auth/spotify-status')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ has_credentials: false, client_id: null }) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
   })
 
   describe('service selector', () => {
@@ -144,7 +152,12 @@ describe('OnboardingWizard', () => {
     it('shows error when token storage fails after OAuth callback', async () => {
       window.history.replaceState({}, '', '/auth/spotify/callback?code=abc')
       localStorage.setItem('spotify_client_id', 'cid')
-      fetch.mockResolvedValueOnce({ ok: false, json: async () => ({ detail: 'Server error' }) })
+      fetch.mockImplementation((url) => {
+        if (typeof url === 'string' && url.includes('/auth/spotify-status')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ has_credentials: false, client_id: null }) })
+        }
+        return Promise.resolve({ ok: false, json: () => Promise.resolve({ detail: 'Server error' }) })
+      })
       const onComplete = vi.fn()
       render(<OnboardingWizard session={fakeSession} onComplete={onComplete} />)
       await waitFor(() => expect(screen.getByText(/server error/i)).toBeInTheDocument())
@@ -175,8 +188,9 @@ describe('OnboardingWizard', () => {
       const onComplete = vi.fn()
       render(<OnboardingWizard session={fakeSession} onComplete={onComplete} />)
       await waitFor(() => expect(onComplete).toHaveBeenCalled())
-      // Should NOT call fetch for token exchange
-      expect(fetch).not.toHaveBeenCalled()
+      // Should NOT call fetch for token exchange (spotify-status pre-fill is ok)
+      const tokenCalls = fetch.mock.calls.filter(([url]) => typeof url === 'string' && url.includes('/auth/spotify-token'))
+      expect(tokenCalls).toHaveLength(0)
       window.history.replaceState({}, '', '/')
     })
 

--- a/frontend/src/components/OnboardingWizard.test.jsx
+++ b/frontend/src/components/OnboardingWizard.test.jsx
@@ -205,10 +205,10 @@ describe('OnboardingWizard', () => {
       mockIsPreview = false
     })
 
-    it('shows proxy redirect URI note when IS_PREVIEW is true', () => {
+    it('does not show proxy redirect URI note in UI', () => {
       localStorage.setItem('music_service_type', 'spotify')
       render(<OnboardingWizard session={fakeSession} onComplete={vi.fn()} />)
-      expect(screen.getByText(/callback-proxy/i)).toBeInTheDocument()
+      expect(screen.queryByText(/callback-proxy/i)).not.toBeInTheDocument()
     })
 
     it('passes supabase token to initiateLogin on preview', async () => {

--- a/frontend/src/components/OnboardingWizard.test.jsx
+++ b/frontend/src/components/OnboardingWizard.test.jsx
@@ -11,15 +11,21 @@ vi.stubGlobal('localStorage', (() => {
   }
 })())
 
+const mockInitiateLogin = vi.fn()
 vi.mock('../hooks/useSpotifyAuth', () => ({
   useSpotifyAuth: () => ({
-    initiateLogin: vi.fn(),
+    initiateLogin: mockInitiateLogin,
     handleCallback: vi.fn().mockResolvedValue({
       access_token: 'acc', refresh_token: 'ref', expires_in: 3600,
     }),
     accessToken: null,
     logout: vi.fn(),
   }),
+}))
+
+let mockIsPreview = false
+vi.mock('../previewMode', () => ({
+  get IS_PREVIEW() { return mockIsPreview },
 }))
 
 vi.stubGlobal('fetch', vi.fn())
@@ -159,6 +165,62 @@ describe('OnboardingWizard', () => {
       render(<OnboardingWizard session={fakeSession} onComplete={vi.fn()} />)
       fireEvent.click(screen.getByRole('button', { name: /back/i }))
       expect(screen.getByText(/choose your music service/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('proxy callback (preview mode)', () => {
+    it('calls onComplete without token exchange when proxy_success=true', async () => {
+      window.history.replaceState({}, '', '/?proxy_success=true')
+      localStorage.setItem('music_service_type', 'spotify')
+      const onComplete = vi.fn()
+      render(<OnboardingWizard session={fakeSession} onComplete={onComplete} />)
+      await waitFor(() => expect(onComplete).toHaveBeenCalled())
+      // Should NOT call fetch for token exchange
+      expect(fetch).not.toHaveBeenCalled()
+      window.history.replaceState({}, '', '/')
+    })
+
+    it('still does normal PKCE exchange when code= is present (not proxy)', async () => {
+      window.history.replaceState({}, '', '/auth/spotify/callback?code=abc')
+      localStorage.setItem('spotify_client_id', 'cid')
+      fetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+      const onComplete = vi.fn()
+      render(<OnboardingWizard session={fakeSession} onComplete={onComplete} />)
+      await waitFor(() => expect(onComplete).toHaveBeenCalled())
+      // Should call fetch for token storage
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/auth/spotify-token'),
+        expect.objectContaining({ method: 'POST' }),
+      )
+      window.history.replaceState({}, '', '/')
+    })
+  })
+
+  describe('preview mode UI', () => {
+    beforeEach(() => {
+      mockIsPreview = true
+    })
+
+    afterEach(() => {
+      mockIsPreview = false
+    })
+
+    it('shows proxy redirect URI note when IS_PREVIEW is true', () => {
+      localStorage.setItem('music_service_type', 'spotify')
+      render(<OnboardingWizard session={fakeSession} onComplete={vi.fn()} />)
+      expect(screen.getByText(/callback-proxy/i)).toBeInTheDocument()
+    })
+
+    it('passes supabase token to initiateLogin on preview', async () => {
+      localStorage.setItem('music_service_type', 'spotify')
+      render(<OnboardingWizard session={fakeSession} onComplete={vi.fn()} />)
+      fireEvent.change(screen.getByPlaceholderText(/client id/i), {
+        target: { value: 'my-client-id' }
+      })
+      fireEvent.click(screen.getByRole('button', { name: /connect spotify/i }))
+      await waitFor(() => {
+        expect(mockInitiateLogin).toHaveBeenCalledWith('supabase-jwt')
+      })
     })
   })
 })

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -18,12 +18,15 @@ const PREVIEW_SESSION = {
   },
 }
 
+const previewRealSpotify = IS_PREVIEW && import.meta.env.VITE_PREVIEW_REAL_SPOTIFY === 'true'
+const usePreviewBypass = IS_PREVIEW && !previewRealSpotify
+
 export function useAuth() {
-  const [session, setSession] = useState(IS_PREVIEW ? PREVIEW_SESSION : null)
-  const [loading, setLoading] = useState(!IS_PREVIEW)
+  const [session, setSession] = useState(usePreviewBypass ? PREVIEW_SESSION : null)
+  const [loading, setLoading] = useState(!usePreviewBypass)
 
   useEffect(() => {
-    if (IS_PREVIEW) return
+    if (usePreviewBypass) return
 
     supabase.auth.getSession().then(({ data: { session } }) => {
       setSession(session)
@@ -41,7 +44,7 @@ export function useAuth() {
   }, [])
 
   async function logout() {
-    if (IS_PREVIEW) return
+    if (usePreviewBypass) return
     await supabase.auth.signOut()
   }
 

--- a/frontend/src/hooks/useSpotifyAuth.js
+++ b/frontend/src/hooks/useSpotifyAuth.js
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react'
+import { IS_PREVIEW } from '../previewMode'
 
 const SCOPES = [
   'user-library-read',
@@ -8,6 +9,7 @@ const SCOPES = [
 ].join(' ')
 
 const REDIRECT_URI = import.meta.env.VITE_SPOTIFY_REDIRECT_URI ?? 'http://localhost:5173/auth/spotify/callback'
+const PROD_ORIGIN = import.meta.env.VITE_PROD_ORIGIN ?? 'https://thedeathofshuffle.com'
 
 function base64URLEncode(buffer) {
   const bytes = new Uint8Array(buffer)
@@ -75,9 +77,22 @@ function storeTokens({ access_token, refresh_token, expires_in }) {
 export function useSpotifyAuth() {
   const [accessToken, setAccessToken] = useState(() => getStoredToken())
 
-  const initiateLogin = useCallback(async () => {
+  const initiateLogin = useCallback(async (supabaseToken) => {
     const clientId = localStorage.getItem('spotify_client_id')
     if (!clientId) throw new Error('No Spotify client_id set')
+
+    if (IS_PREVIEW && supabaseToken) {
+      // Preview mode: route OAuth through prod's proxy endpoint
+      const params = new URLSearchParams({
+        origin: window.location.origin,
+        client_id: clientId,
+        supabase_token: supabaseToken,
+      })
+      window.location.assign(`${PROD_ORIGIN}/api/auth/preview-login?${params}`)
+      return
+    }
+
+    // Prod mode: direct PKCE flow
     const verifier = generateCodeVerifier()
     const challenge = await generateCodeChallenge(verifier)
     localStorage.setItem('spotify_pkce_verifier', verifier)

--- a/frontend/src/hooks/useSpotifyAuth.test.js
+++ b/frontend/src/hooks/useSpotifyAuth.test.js
@@ -22,6 +22,11 @@ vi.stubGlobal('localStorage', (() => {
 
 vi.stubGlobal('fetch', vi.fn())
 
+let mockIsPreview = false
+vi.mock('../previewMode', () => ({
+  get IS_PREVIEW() { return mockIsPreview },
+}))
+
 import { useSpotifyAuth } from './useSpotifyAuth'
 
 describe('useSpotifyAuth', () => {
@@ -87,5 +92,73 @@ describe('useSpotifyAuth', () => {
     expect(localStorage.getItem('spotify_access_token')).toBeNull()
     expect(localStorage.getItem('spotify_refresh_token')).toBeNull()
     expect(localStorage.getItem('spotify_expires_in')).toBeNull()
+  })
+
+  describe('preview proxy login', () => {
+    beforeEach(() => {
+      mockIsPreview = true
+    })
+
+    afterEach(() => {
+      mockIsPreview = false
+    })
+
+    it('redirects to prod proxy URL when IS_PREVIEW is true', async () => {
+      const assignMock = vi.fn()
+      Object.defineProperty(window, 'location', {
+        value: { assign: assignMock, origin: 'https://preview-123.vercel.app' },
+        writable: true,
+      })
+      localStorage.setItem('spotify_client_id', 'my-client-id')
+
+      const { result } = renderHook(() => useSpotifyAuth())
+      await act(async () => {
+        await result.current.initiateLogin('supabase-jwt-token')
+      })
+
+      expect(assignMock).toHaveBeenCalledTimes(1)
+      const url = assignMock.mock.calls[0][0]
+      expect(url).toContain('/api/auth/preview-login')
+      expect(url).toContain('origin=')
+      expect(url).toContain('client_id=my-client-id')
+      expect(url).toContain('supabase_token=supabase-jwt-token')
+      // Should NOT set a PKCE verifier (prod proxy handles it)
+      expect(localStorage.getItem('spotify_pkce_verifier')).toBeNull()
+    })
+
+    it('uses VITE_PROD_ORIGIN for the proxy base URL', async () => {
+      const assignMock = vi.fn()
+      Object.defineProperty(window, 'location', {
+        value: { assign: assignMock, origin: 'https://preview-123.vercel.app' },
+        writable: true,
+      })
+      localStorage.setItem('spotify_client_id', 'cid')
+
+      // The proxy URL should start with the prod origin
+      const { result } = renderHook(() => useSpotifyAuth())
+      await act(async () => {
+        await result.current.initiateLogin('tok')
+      })
+
+      const url = assignMock.mock.calls[0][0]
+      // Should use the VITE_PROD_ORIGIN env var (or fallback)
+      expect(url).toMatch(/^https?:\/\//)
+      expect(url).toContain('/api/auth/preview-login')
+    })
+  })
+
+  it('initiateLogin does direct PKCE on prod (not preview)', async () => {
+    // Ensure IS_PREVIEW is false (default)
+    mockIsPreview = false
+
+    const assignMock = vi.fn()
+    Object.defineProperty(window, 'location', { value: { assign: assignMock }, writable: true })
+    localStorage.setItem('spotify_client_id', 'my-client-id')
+
+    const { result } = renderHook(() => useSpotifyAuth())
+    await act(async () => { await result.current.initiateLogin() })
+
+    expect(assignMock).toHaveBeenCalledWith(expect.stringContaining('accounts.spotify.com/authorize'))
+    expect(localStorage.getItem('spotify_pkce_verifier')).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Summary

- Backend: HMAC-signed OAuth callback proxy (`/auth/preview-login` + `/auth/callback-proxy`) routes preview Spotify auth through prod's stable URL
- Frontend: `IS_PREVIEW` path in `useSpotifyAuth` redirects through proxy; `OnboardingWizard` handles `?proxy_success=true` callback
- `VITE_PREVIEW_REAL_SPOTIFY=true` env var toggles real Spotify on previews while keeping Supabase bypass

Closes #23

## Config done

- [x] Supabase: wildcard redirect URL added (`*-toofanians-projects.vercel.app`)
- [x] Spotify Dashboard: `https://thedeathofshuffle.com/api/auth/callback-proxy` added as redirect URI
- [x] Vercel prod env: `SPOTIFY_PROXY_SECRET` and `SPOTIFY_PROXY_REDIRECT_URI` set

## Still needed

- [ ] Set `VITE_PREVIEW_REAL_SPOTIFY=true` in Vercel preview env scope
- [ ] Set `VITE_PROD_ORIGIN=https://thedeathofshuffle.com` in Vercel preview env scope
- [ ] Smoke test on preview deploy

## Test plan

- [ ] Open preview deploy → should show Spotify onboarding (not bypass)
- [ ] Enter Client ID → redirects to prod proxy → Spotify auth → returns to preview with `proxy_success=true`
- [ ] After auth, library syncs with real Spotify data
- [ ] Prod deploy unaffected — existing PKCE flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)