### PR TITLE
[6] Remove collection play button

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -72,10 +72,6 @@ export default function App() {
   const isMobile = useIsMobile()
   const [selectedAlbumIds, setSelectedAlbumIds] = useState(new Set())
   const [targetArtist, setTargetArtist] = useState(null)
-  // Collection playback: null | { collectionId: string, albumIds: string[], currentIndex: number }
-  const [collectionPlayback, setCollectionPlayback] = useState(null)
-  const collectionPlaybackRef = useRef(null)
-  collectionPlaybackRef.current = collectionPlayback
   const isInCollection = view !== 'home' && view !== 'library' && view !== 'collections'
   const artistCount = useMemo(() => {
     const artists = new Set()
@@ -397,16 +393,6 @@ export default function App() {
     }
   }, [play, pause, serviceType, albums, collectionAlbums])
 
-  const handlePlayRef = useRef(handlePlay)
-  handlePlayRef.current = handlePlay
-
-  async function handlePlayCollection() {
-    if (!isInCollection || !collectionAlbums.length) return
-    const albumIds = collectionAlbums.map(a => a.service_id)
-    setCollectionPlayback({ collectionId: view.id, albumIds, currentIndex: 0 })
-    await handlePlay(albumIds[0])
-  }
-
   const handleModalDeviceSelected = useCallback(async (deviceId) => {
     const intent = pendingPlayIntent
     if (!intent) return
@@ -562,40 +548,6 @@ export default function App() {
     ))
     setSelectedAlbumIds(new Set())
   }
-
-  // Auto-advance to next album when current album finishes in collection playback
-  useEffect(() => {
-    const cp = collectionPlaybackRef.current
-    if (!cp) return
-
-    const currentAlbumId = cp.albumIds[cp.currentIndex]
-    const currentAlbum = albums.find(a => a.service_id === currentAlbumId) ||
-                         collectionAlbums.find(a => a.service_id === currentAlbumId)
-    if (!currentAlbum) return
-
-    const playbackAlbumServiceId = playback.track?.album_service_id
-    const playbackAlbumName = playback.track?.album
-    const isCurrentAlbumPlaying = playbackAlbumServiceId
-      ? playbackAlbumServiceId === currentAlbum.service_id
-      : playbackAlbumName === currentAlbum.name
-
-    if (!isCurrentAlbumPlaying && playingIdRef.current === currentAlbumId) {
-      const nextIndex = cp.currentIndex + 1
-      if (nextIndex < cp.albumIds.length) {
-        setCollectionPlayback(prev => prev ? { ...prev, currentIndex: nextIndex } : null)
-        handlePlayRef.current(cp.albumIds[nextIndex])
-      } else {
-        setCollectionPlayback(null)
-      }
-    }
-  }, [playback.track?.album_service_id, playback.track?.album, playback.is_playing])
-
-  // Clear collection playback if we navigate to a different collection
-  useEffect(() => {
-    if (collectionPlayback && isInCollection && view.id !== collectionPlayback.collectionId) {
-      setCollectionPlayback(null)
-    }
-  }, [view])
 
   // Auth gate
   const isSpotifyCallback = window.location.pathname === '/auth/spotify/callback'
@@ -817,7 +769,6 @@ export default function App() {
                 albumCount={filterAlbums(collectionAlbums, search).length}
                 onBack={() => setView('collections')}
                 onDescriptionChange={(desc) => handleUpdateCollectionDescription(view.id, desc)}
-                onPlay={handlePlayCollection}
               />
               <div className="flex-1 overflow-y-auto">
                 <AlbumTable
@@ -1045,7 +996,6 @@ export default function App() {
               albumCount={filterAlbums(collectionAlbums, search).length}
               onBack={() => setView('collections')}
               onDescriptionChange={(desc) => handleUpdateCollectionDescription(view.id, desc)}
-              onPlay={handlePlayCollection}
             />
             <div className="flex-1 overflow-y-auto pb-16">
               <AlbumTable

--- a/frontend/src/components/CollectionDetailHeader.jsx
+++ b/frontend/src/components/CollectionDetailHeader.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 
-export default function CollectionDetailHeader({ name, description, albumCount, onBack, onDescriptionChange, onPlay }) {
+export default function CollectionDetailHeader({ name, description, albumCount, onBack, onDescriptionChange }) {
   const [desc, setDesc] = useState(description || '')
 
   function handleBlur() {
@@ -24,15 +24,6 @@ export default function CollectionDetailHeader({ name, description, albumCount, 
           onKeyDown={e => e.key === 'Enter' && e.target.blur()}
         />
       </div>
-      {albumCount > 0 && onPlay && (
-        <button
-          aria-label="Play collection"
-          className="bg-accent text-white border-none rounded-full w-8 h-8 flex items-center justify-center cursor-pointer flex-shrink-0 hover:brightness-110 transition-all duration-150"
-          onClick={onPlay}
-        >
-          ▶
-        </button>
-      )}
       <span className="text-sm text-text-dim flex-shrink-0">{albumCount} albums</span>
     </div>
   )

--- a/frontend/src/components/CollectionDetailHeader.test.jsx
+++ b/frontend/src/components/CollectionDetailHeader.test.jsx
@@ -76,8 +76,7 @@ describe('CollectionDetailHeader', () => {
     expect(onBack).toHaveBeenCalled()
   })
 
-  it('shows play button and calls onPlay when clicked', async () => {
-    const onPlay = vi.fn()
+  it('does not show play button', () => {
     render(
       <CollectionDetailHeader
         name="Late Night"
@@ -85,24 +84,6 @@ describe('CollectionDetailHeader', () => {
         albumCount={5}
         onBack={() => {}}
         onDescriptionChange={() => {}}
-        onPlay={onPlay}
-      />
-    )
-    const playButton = screen.getByRole('button', { name: /play collection/i })
-    expect(playButton).toBeInTheDocument()
-    await userEvent.click(playButton)
-    expect(onPlay).toHaveBeenCalled()
-  })
-
-  it('does not show play button when albumCount is 0', () => {
-    render(
-      <CollectionDetailHeader
-        name="Empty Collection"
-        description={null}
-        albumCount={0}
-        onBack={() => {}}
-        onDescriptionChange={() => {}}
-        onPlay={() => {}}
       />
     )
     expect(screen.queryByRole('button', { name: /play collection/i })).not.toBeInTheDocument()


### PR DESCRIPTION
## Summary
- Remove play button from CollectionDetailHeader — random album selection contradicts intentional listening thesis
- Remove `collectionPlayback` state, `handlePlayCollection`, auto-advance polling, and collection navigation cleanup effects from App.jsx
- Update tests: replace play button test with assertion that button no longer exists

Closes #6

## Test plan
- [x] CollectionDetailHeader tests pass (6/6)
- [x] Verify collection detail view renders without play button
- [x] Verify individual album play and PlaybackBar controls still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)