### PR TITLE
[40] Fix Recently Played showing only one album

### DIFF
--- a/frontend/src/components/AlbumRow.jsx
+++ b/frontend/src/components/AlbumRow.jsx
@@ -21,16 +21,16 @@ export default function AlbumRow({ title, albums, onPlay }) {
       >
         {albums.map(album => (
           <div
-            key={album.spotify_id}
+            key={album.service_id}
             className="flex-shrink-0 w-[110px] md:w-auto cursor-pointer active:scale-95 active:opacity-80 md:hover:scale-[1.03] md:hover:shadow-lg transition-transform duration-150"
             style={{ scrollSnapAlign: 'start' }}
-            data-testid={`album-card-${album.spotify_id}`}
+            data-testid={`album-card-${album.service_id}`}
             onPointerDown={e => { pointerStart.current = { x: e.clientX, y: e.clientY } }}
             onClick={e => {
               const dx = Math.abs(e.clientX - pointerStart.current.x)
               const dy = Math.abs(e.clientY - pointerStart.current.y)
               if (dx > 10 || dy > 10) return
-              onPlay(album.spotify_id)
+              onPlay(album.service_id)
             }}
           >
             {album.image_url ? (

--- a/frontend/src/components/AlbumRow.test.jsx
+++ b/frontend/src/components/AlbumRow.test.jsx
@@ -3,8 +3,8 @@ import { describe, it, expect, vi } from 'vitest'
 import AlbumRow from './AlbumRow'
 
 const ALBUMS = [
-  { spotify_id: 'a1', name: 'Album One', artists: ['Artist A'], image_url: 'https://img/1.jpg' },
-  { spotify_id: 'a2', name: 'Album Two', artists: ['Artist B', 'Artist C'], image_url: 'https://img/2.jpg' },
+  { service_id: 'a1', name: 'Album One', artists: ['Artist A'], image_url: 'https://img/1.jpg' },
+  { service_id: 'a2', name: 'Album Two', artists: ['Artist B', 'Artist C'], image_url: 'https://img/2.jpg' },
 ]
 
 describe('AlbumRow', () => {
@@ -28,7 +28,7 @@ describe('AlbumRow', () => {
     expect(images[0]).toHaveAttribute('src', 'https://img/1.jpg')
   })
 
-  it('calls onPlay with spotify_id on click', () => {
+  it('calls onPlay with service_id on click', () => {
     const onPlay = vi.fn()
     render(<AlbumRow title="Today" albums={ALBUMS} onPlay={onPlay} />)
     fireEvent.click(screen.getByText('Album One').closest('[data-testid]'))

--- a/frontend/src/components/HomePage.jsx
+++ b/frontend/src/components/HomePage.jsx
@@ -18,8 +18,8 @@ function mergeRecentlyPlayed(today, thisWeek) {
   const seen = new Set()
   const merged = []
   for (const album of [...today, ...thisWeek]) {
-    if (!seen.has(album.spotify_id)) {
-      seen.add(album.spotify_id)
+    if (!seen.has(album.service_id)) {
+      seen.add(album.service_id)
       merged.push(album)
     }
   }

--- a/frontend/src/components/HomePage.test.jsx
+++ b/frontend/src/components/HomePage.test.jsx
@@ -4,19 +4,19 @@ import HomePage from './HomePage'
 
 const HOME_DATA = {
   today: [
-    { spotify_id: 'a1', name: 'Today Album', artists: ['Artist A'], image_url: 'https://img/1.jpg' },
+    { service_id: 'a1', name: 'Today Album', artists: ['Artist A'], image_url: 'https://img/1.jpg' },
   ],
   this_week: [
-    { spotify_id: 'a2', name: 'Week Album', artists: ['Artist B'], image_url: 'https://img/2.jpg' },
+    { service_id: 'a2', name: 'Week Album', artists: ['Artist B'], image_url: 'https://img/2.jpg' },
   ],
   recently_added: [
-    { spotify_id: 'a5', name: 'New Album', artists: ['Artist D'], image_url: 'https://img/5.jpg' },
+    { service_id: 'a5', name: 'New Album', artists: ['Artist D'], image_url: 'https://img/5.jpg' },
   ],
   rediscover: [
-    { spotify_id: 'a3', name: 'Old Gem', artists: ['Artist C'], image_url: 'https://img/3.jpg' },
+    { service_id: 'a3', name: 'Old Gem', artists: ['Artist C'], image_url: 'https://img/3.jpg' },
   ],
   recommended: [
-    { spotify_id: 'a4', name: 'Try This', artists: ['Artist A'], image_url: 'https://img/4.jpg' },
+    { service_id: 'a4', name: 'Try This', artists: ['Artist A'], image_url: 'https://img/4.jpg' },
   ],
 }
 
@@ -39,11 +39,11 @@ describe('HomePage', () => {
     const duped = {
       ...HOME_DATA,
       today: [
-        { spotify_id: 'a1', name: 'Today Album', artists: ['Artist A'], image_url: 'https://img/1.jpg' },
+        { service_id: 'a1', name: 'Today Album', artists: ['Artist A'], image_url: 'https://img/1.jpg' },
       ],
       this_week: [
-        { spotify_id: 'a1', name: 'Today Album', artists: ['Artist A'], image_url: 'https://img/1.jpg' },
-        { spotify_id: 'a2', name: 'Week Album', artists: ['Artist B'], image_url: 'https://img/2.jpg' },
+        { service_id: 'a1', name: 'Today Album', artists: ['Artist A'], image_url: 'https://img/1.jpg' },
+        { service_id: 'a2', name: 'Week Album', artists: ['Artist B'], image_url: 'https://img/2.jpg' },
       ],
     }
     global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(duped) })


### PR DESCRIPTION
## Summary
- Fix `spotify_id → service_id` field name mismatch in `AlbumRow.jsx` and `HomePage.jsx`
- The backend renamed the field in commit c34c221 but these two components were missed
- All albums had `undefined` keys, causing React to render only one and `mergeRecentlyPlayed` to deduplicate everything into a single entry

Fixes #40

## Test plan
- [x] All 16 affected tests pass (`AlbumRow.test.jsx`, `HomePage.test.jsx`)
- [ ] Verify preview deploy shows multiple recently played albums

🤖 Generated with [Claude Code](https://claude.com/claude-code)