### PR TITLE
[58] Fix light-mode invisible playback and volume bars

### DIFF
--- a/frontend/src/components/PlaybackBar.jsx
+++ b/frontend/src/components/PlaybackBar.jsx
@@ -51,11 +51,11 @@ function ProgressBar({ progressMs, durationMs, onSeek }) {
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         className="flex-1 h-1.5 rounded-sm relative overflow-hidden"
-        style={{ cursor: onSeek ? 'pointer' : 'default', background: 'rgba(255,255,255,0.2)' }}
+        style={{ cursor: onSeek ? 'pointer' : 'default', background: 'color-mix(in srgb, var(--color-text-dim) 25%, transparent)' }}
       >
         <div
           className="absolute left-0 top-0 bottom-0 rounded-sm transition-[width] duration-300 ease-linear"
-          style={{ background: 'rgba(255,255,255,0.85)', width: `${pct * 100}%` }}
+          style={{ background: 'var(--color-accent)', width: `${pct * 100}%` }}
         />
       </div>
       <span className="text-xs text-text-dim min-w-8 tabular-nums">{formatTime(durationMs)}</span>
@@ -107,9 +107,9 @@ function VolumeSlider({ value, onChange }) {
         onKeyDown={handleKeyDown}
         style={{ position: 'relative', width: '100px', height: `${THUMB}px`, cursor: 'pointer', display: 'flex', alignItems: 'center', flexShrink: 0 }}
       >
-        <div style={{ position: 'absolute', left: 0, right: 0, height: '4px', background: 'rgba(255,255,255,0.2)', borderRadius: '2px' }} />
-        <div style={{ position: 'absolute', left: 0, width: `calc(${pct} * 100%)`, height: '4px', background: 'rgba(255,255,255,0.85)', borderRadius: '2px' }} />
-        <div style={{ position: 'absolute', left: `calc(${pct} * (100% - ${THUMB}px))`, width: `${THUMB}px`, height: `${THUMB}px`, borderRadius: '50%', background: '#ffffff' }} />
+        <div style={{ position: 'absolute', left: 0, right: 0, height: '4px', background: 'color-mix(in srgb, var(--color-text-dim) 25%, transparent)', borderRadius: '2px' }} />
+        <div style={{ position: 'absolute', left: 0, width: `calc(${pct} * 100%)`, height: '4px', background: 'var(--color-accent)', borderRadius: '2px' }} />
+        <div style={{ position: 'absolute', left: `calc(${pct} * (100% - ${THUMB}px))`, width: `${THUMB}px`, height: `${THUMB}px`, borderRadius: '50%', background: 'var(--color-accent)' }} />
       </div>
     </div>
   )

--- a/frontend/src/components/PlaybackBar.test.jsx
+++ b/frontend/src/components/PlaybackBar.test.jsx
@@ -739,6 +739,61 @@ describe('PlaybackBar', () => {
     expect(btn.className).toContain('rounded-full')
   })
 
+  // --- Theme-aware slider colors ---
+
+  it('progress bar track uses theme CSS variable, not hardcoded white', () => {
+    render(
+      <PlaybackBar
+        state={PLAYING_STATE}
+        onPlay={vi.fn()}
+        onPause={vi.fn()}
+        paneOpen={false}
+        onTogglePane={vi.fn()}
+      />
+    )
+    const slider = screen.getByRole('slider', { name: /track progress/i })
+    expect(slider.style.background).not.toContain('rgba(255')
+    expect(slider.style.background).toContain('var(--color-text-dim)')
+  })
+
+  it('progress bar filled track uses theme CSS variable, not hardcoded white', () => {
+    render(
+      <PlaybackBar
+        state={PLAYING_STATE}
+        onPlay={vi.fn()}
+        onPause={vi.fn()}
+        paneOpen={false}
+        onTogglePane={vi.fn()}
+      />
+    )
+    const slider = screen.getByRole('slider', { name: /track progress/i })
+    const fill = slider.firstElementChild
+    expect(fill.style.background).not.toContain('rgba(255')
+    expect(fill.style.background).toContain('var(--color-accent)')
+  })
+
+  it('volume slider elements use theme CSS variables, not hardcoded white', () => {
+    render(
+      <PlaybackBar
+        state={PLAYING_STATE}
+        onPlay={vi.fn()}
+        onPause={vi.fn()}
+        paneOpen={false}
+        onTogglePane={vi.fn()}
+        onSetVolume={vi.fn()}
+      />
+    )
+    const slider = screen.getByRole('slider', { name: 'Volume' })
+    const children = slider.children
+    // track background (first child)
+    expect(children[0].style.background).not.toContain('rgba(255')
+    // filled track (second child)
+    expect(children[1].style.background).not.toContain('rgba(255')
+    // thumb (third child)
+    expect(children[2].style.background).not.toBe('#ffffff')
+    expect(children[2].style.background).toContain('var(--color-accent)')
+  })
+
   // --- Volume slider ---
 
   it('renders a volume slider in the right zone', () => {


### PR DESCRIPTION
## Summary
- Replace hardcoded white RGBA colors in ProgressBar and VolumeSlider with theme-aware CSS custom properties (`--color-text-dim`, `--color-accent`)
- Track backgrounds use `color-mix(in srgb, var(--color-text-dim) 25%, transparent)` for subtle unfilled appearance
- Filled tracks and volume thumb use `var(--color-accent)` which swaps between light (#606060) and dark (#c0c0c0)

## Test plan
- [x] 3 new tests verify no hardcoded `rgba(255,...)` values remain in slider styles
- [x] All 444 existing tests pass
- [ ] Visual check: bars visible in both light and dark mode on preview deploy

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)