### PR TITLE
[49] Add collection rename

### DIFF
--- a/backend/routers/metadata.py
+++ b/backend/routers/metadata.py
@@ -139,6 +139,22 @@ def delete_collection(
     return {"deleted": True}
 
 
+@router.patch("/collections/{collection_id}")
+def rename_collection(
+    collection_id: str,
+    body: CollectionBody,
+    db=Depends(get_authed_db),
+    sp: spotipy.Spotify = Depends(get_user_spotify),
+):
+    result = (
+        db.table("collections")
+        .update({"name": body.name})
+        .eq("id", collection_id)
+        .execute()
+    )
+    return result.data[0]
+
+
 @router.put("/collections/{collection_id}/description")
 def update_collection_description(
     collection_id: str,

--- a/backend/tests/test_metadata.py
+++ b/backend/tests/test_metadata.py
@@ -402,6 +402,33 @@ def test_get_collection_albums_returns_empty_when_collection_empty(monkeypatch):
     clear_overrides()
 
 
+# --- Collection rename ---
+
+
+def test_rename_collection():
+    db = mock_db(execute_data=[{**COLLECTION, "name": "New name"}])
+    override_db(db)
+    override_spotify(mock_spotify())
+
+    response = client.patch("/collections/col-uuid-1", json={"name": "New name"})
+
+    assert response.status_code == 200
+    assert response.json()["name"] == "New name"
+
+    clear_overrides()
+
+
+def test_rename_collection_rejects_empty_name():
+    override_db(mock_db())
+    override_spotify(mock_spotify())
+
+    response = client.patch("/collections/col-uuid-1", json={"name": ""})
+
+    assert response.status_code == 422
+
+    clear_overrides()
+
+
 # --- Collection description ---
 
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -279,6 +279,23 @@ export default function App() {
     }
   }
 
+  async function handleRenameCollection(id, newName) {
+    const prev = collections
+    setCollections(cs => cs.map(c => c.id === id ? { ...c, name: newName } : c))
+    // Also update the view if we're inside this collection
+    setView(v => typeof v === 'object' && v.id === id ? { ...v, name: newName } : v)
+    try {
+      const res = await apiFetch(`/collections/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newName }),
+      }, sessionRef.current)
+      if (!res.ok) throw new Error('Failed to rename collection')
+    } catch {
+      setCollections(prev)
+    }
+  }
+
   async function handleDeleteCollection(id) {
     // Optimistic update: remove the collection and its album memberships from
     // state immediately. Keep a snapshot of both for rollback if the API call
@@ -814,6 +831,7 @@ export default function App() {
                 collections={collections}
                 onEnter={handleEnterCollection}
                 onDelete={handleDeleteCollection}
+                onRename={handleRenameCollection}
                 onCreate={handleCreateCollection}
                 onFetchAlbums={handleFetchCollectionAlbums}
               />
@@ -835,6 +853,7 @@ export default function App() {
                 albumCount={collectionAlbums.length}
                 onBack={() => setView('collections')}
                 onDescriptionChange={(desc) => handleUpdateCollectionDescription(view.id, desc)}
+                onRename={(newName) => handleRenameCollection(view.id, newName)}
                 onPlay={handlePlayCollection}
               />
               <div className="flex-1 overflow-y-auto">
@@ -1089,6 +1108,7 @@ export default function App() {
               }) : collections}
               onEnter={handleEnterCollection}
               onDelete={handleDeleteCollection}
+              onRename={handleRenameCollection}
               onCreate={handleCreateCollection}
               onFetchAlbums={handleFetchCollectionAlbums}
             />
@@ -1110,6 +1130,7 @@ export default function App() {
               albumCount={filterAlbums(collectionAlbums, search).length}
               onBack={() => setView('collections')}
               onDescriptionChange={(desc) => handleUpdateCollectionDescription(view.id, desc)}
+              onRename={(newName) => handleRenameCollection(view.id, newName)}
               onPlay={handlePlayCollection}
             />
             <div className="flex-1 overflow-y-auto pb-16">

--- a/frontend/src/components/CollectionDetailHeader.jsx
+++ b/frontend/src/components/CollectionDetailHeader.jsx
@@ -1,9 +1,19 @@
 import { useState } from 'react'
 
-export default function CollectionDetailHeader({ name, description, albumCount, onBack, onDescriptionChange }) {
+export default function CollectionDetailHeader({ name, description, albumCount, onBack, onDescriptionChange, onRename }) {
+  const [editName, setEditName] = useState(name || '')
   const [desc, setDesc] = useState(description || '')
 
-  function handleBlur() {
+  function handleNameBlur() {
+    const trimmed = editName.trim()
+    if (trimmed && trimmed !== name) {
+      onRename(trimmed)
+    } else {
+      setEditName(name || '')
+    }
+  }
+
+  function handleDescBlur() {
     const trimmed = desc.trim()
     if (trimmed !== (description || '')) {
       onDescriptionChange(trimmed || null)
@@ -14,13 +24,20 @@ export default function CollectionDetailHeader({ name, description, albumCount, 
     <div className="flex items-center gap-3 px-4 py-2 border-b border-border bg-surface flex-shrink-0">
       <button className="text-sm text-text-dim transition-colors duration-150 hover:text-text" onClick={onBack}>← Back</button>
       <div className="flex-1 min-w-0">
-        <h2 className="text-base font-semibold">{name}</h2>
+        <input
+          className="text-base font-semibold bg-transparent border-none w-full p-0 outline-none"
+          placeholder="Collection name"
+          value={editName}
+          onChange={e => setEditName(e.target.value)}
+          onBlur={handleNameBlur}
+          onKeyDown={e => e.key === 'Enter' && e.target.blur()}
+        />
         <input
           className="bg-transparent border-none text-xs text-text-dim w-full p-0 outline-none"
           placeholder="Add a description…"
           value={desc}
           onChange={e => setDesc(e.target.value)}
-          onBlur={handleBlur}
+          onBlur={handleDescBlur}
           onKeyDown={e => e.key === 'Enter' && e.target.blur()}
         />
       </div>

--- a/frontend/src/components/CollectionDetailHeader.test.jsx
+++ b/frontend/src/components/CollectionDetailHeader.test.jsx
@@ -14,7 +14,7 @@ describe('CollectionDetailHeader', () => {
         onDescriptionChange={() => {}}
       />
     )
-    expect(screen.getByText('Late Night')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Late Night')).toBeInTheDocument()
     expect(screen.getByDisplayValue('low energy vibes')).toBeInTheDocument()
   })
 
@@ -87,5 +87,77 @@ describe('CollectionDetailHeader', () => {
       />
     )
     expect(screen.queryByRole('button', { name: /play collection/i })).not.toBeInTheDocument()
+  })
+
+  it('allows editing collection name inline', async () => {
+    const onRename = vi.fn()
+    render(
+      <CollectionDetailHeader
+        name="Late Night"
+        description={null}
+        albumCount={5}
+        onBack={() => {}}
+        onDescriptionChange={() => {}}
+        onRename={onRename}
+      />
+    )
+    const input = screen.getByDisplayValue('Late Night')
+    await userEvent.clear(input)
+    await userEvent.type(input, 'Early Morning')
+    await userEvent.tab()
+    expect(onRename).toHaveBeenCalledWith('Early Morning')
+  })
+
+  it('does not call onRename when name is unchanged', async () => {
+    const onRename = vi.fn()
+    render(
+      <CollectionDetailHeader
+        name="Late Night"
+        description={null}
+        albumCount={5}
+        onBack={() => {}}
+        onDescriptionChange={() => {}}
+        onRename={onRename}
+      />
+    )
+    const input = screen.getByDisplayValue('Late Night')
+    await userEvent.tab()
+    expect(onRename).not.toHaveBeenCalled()
+  })
+
+  it('does not call onRename when name is empty', async () => {
+    const onRename = vi.fn()
+    render(
+      <CollectionDetailHeader
+        name="Late Night"
+        description={null}
+        albumCount={5}
+        onBack={() => {}}
+        onDescriptionChange={() => {}}
+        onRename={onRename}
+      />
+    )
+    const input = screen.getByDisplayValue('Late Night')
+    await userEvent.clear(input)
+    await userEvent.tab()
+    expect(onRename).not.toHaveBeenCalled()
+  })
+
+  it('submits name on Enter key', async () => {
+    const onRename = vi.fn()
+    render(
+      <CollectionDetailHeader
+        name="Late Night"
+        description={null}
+        albumCount={5}
+        onBack={() => {}}
+        onDescriptionChange={() => {}}
+        onRename={onRename}
+      />
+    )
+    const input = screen.getByDisplayValue('Late Night')
+    await userEvent.clear(input)
+    await userEvent.type(input, 'Sunrise{Enter}')
+    expect(onRename).toHaveBeenCalledWith('Sunrise')
   })
 })

--- a/frontend/src/components/CollectionsPane.jsx
+++ b/frontend/src/components/CollectionsPane.jsx
@@ -2,10 +2,13 @@ import { useState, useEffect } from 'react'
 import { useIsMobile } from '../hooks/useIsMobile'
 import AlbumArtStrip from './AlbumArtStrip'
 
-export default function CollectionsPane({ collections, onEnter, onDelete, onCreate, onFetchAlbums }) {
+export default function CollectionsPane({ collections, onEnter, onDelete, onCreate, onRename, onFetchAlbums }) {
   const [newName, setNewName] = useState('')
   const [artMap, setArtMap] = useState({})
   const [confirmingId, setConfirmingId] = useState(null)
+  const [menuOpenId, setMenuOpenId] = useState(null)
+  const [renamingId, setRenamingId] = useState(null)
+  const [renameValue, setRenameValue] = useState('')
   const isMobile = useIsMobile()
 
   useEffect(() => {
@@ -20,9 +23,10 @@ export default function CollectionsPane({ collections, onEnter, onDelete, onCrea
   }, [collections])  // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    if (!confirmingId) return
+    if (!confirmingId && !menuOpenId) return
     function handleDocClick() {
       setConfirmingId(null)
+      setMenuOpenId(null)
     }
     const id = setTimeout(() => {
       document.addEventListener('click', handleDocClick)
@@ -31,7 +35,7 @@ export default function CollectionsPane({ collections, onEnter, onDelete, onCrea
       clearTimeout(id)
       document.removeEventListener('click', handleDocClick)
     }
-  }, [confirmingId])
+  }, [confirmingId, menuOpenId])
 
   function handleCreate() {
     if (!newName.trim()) return
@@ -55,6 +59,14 @@ export default function CollectionsPane({ collections, onEnter, onDelete, onCrea
   function handleCancelDelete(e) {
     e.stopPropagation()
     setConfirmingId(null)
+  }
+
+  function submitRename(col) {
+    const trimmed = renameValue.trim()
+    if (trimmed && trimmed !== col.name) {
+      onRename(col.id, trimmed)
+    }
+    setRenamingId(null)
   }
 
   return (
@@ -89,7 +101,22 @@ export default function CollectionsPane({ collections, onEnter, onDelete, onCrea
                     <div className="flex items-center justify-between px-4 py-2">
                       <div className="min-w-0 flex-1">
                         <div className="flex items-center gap-2">
-                          <span className="text-sm font-medium text-text">{col.name}</span>
+                          {renamingId === col.id ? (
+                            <input
+                              className="text-sm font-medium text-text bg-transparent border-b border-accent outline-none w-full"
+                              value={renameValue}
+                              onChange={e => setRenameValue(e.target.value)}
+                              onKeyDown={e => {
+                                if (e.key === 'Enter') submitRename(col)
+                                if (e.key === 'Escape') { setRenamingId(null) }
+                              }}
+                              onBlur={() => submitRename(col)}
+                              autoFocus
+                              onClick={e => e.stopPropagation()}
+                            />
+                          ) : (
+                            <span className="text-sm font-medium text-text">{col.name}</span>
+                          )}
                           {col.album_count != null && (
                             <span className="text-xs text-text-dim">{col.album_count}</span>
                           )}
@@ -98,14 +125,19 @@ export default function CollectionsPane({ collections, onEnter, onDelete, onCrea
                           <div className="text-xs text-text-dim mt-0.5 truncate">{col.description}</div>
                         )}
                       </div>
-                      <div onClick={e => e.stopPropagation()}>
-                        {isConfirming ? (
+                      <div onClick={e => e.stopPropagation()} className="relative">
+                        {renamingId === col.id ? null : confirmingId === col.id ? (
                           <>
                             <button className="bg-delete-red border-none text-white cursor-pointer text-xs font-semibold px-1.5 py-0.5 rounded mr-0.5 whitespace-nowrap" aria-label="Confirm delete" onClick={e => handleConfirmDelete(e, col.id)}>Delete</button>
                             <button className="bg-transparent border border-border text-text-dim cursor-pointer text-xs px-1.5 py-0.5 rounded whitespace-nowrap" aria-label="Cancel" onClick={handleCancelDelete}>Cancel</button>
                           </>
+                        ) : menuOpenId === col.id ? (
+                          <div className="flex gap-1">
+                            <button className="bg-transparent border border-border text-text text-xs px-2 py-1 rounded cursor-pointer hover:bg-surface-2" onClick={() => { setMenuOpenId(null); setRenamingId(col.id); setRenameValue(col.name) }}>Rename</button>
+                            <button className="bg-transparent border border-border text-delete-red text-xs px-2 py-1 rounded cursor-pointer hover:bg-surface-2" onClick={e => { setMenuOpenId(null); handleDeleteClick(e, col.id) }}>Delete</button>
+                          </div>
                         ) : (
-                          <button className="bg-transparent border-none text-text-dim cursor-pointer text-lg p-1.5 rounded opacity-0 group-hover:opacity-50 hover:!opacity-100 hover:bg-surface-2 transition-opacity duration-150" aria-label="Delete" onClick={e => handleDeleteClick(e, col.id)}>×</button>
+                          <button className="bg-transparent border-none text-text-dim cursor-pointer text-lg p-1.5 rounded opacity-0 group-hover:opacity-50 hover:!opacity-100 hover:bg-surface-2 transition-opacity duration-150" aria-label="More options" onClick={() => setMenuOpenId(col.id)}>⋯</button>
                         )}
                       </div>
                     </div>
@@ -117,7 +149,22 @@ export default function CollectionsPane({ collections, onEnter, onDelete, onCrea
                   <div className="flex items-stretch">
                     <div className="w-48 flex-shrink-0 flex items-center px-4">
                       <div className="min-w-0">
-                        <div className="text-sm font-medium text-text truncate">{col.name}</div>
+                        {renamingId === col.id ? (
+                          <input
+                            className="text-sm font-medium text-text bg-transparent border-b border-accent outline-none w-full"
+                            value={renameValue}
+                            onChange={e => setRenameValue(e.target.value)}
+                            onKeyDown={e => {
+                              if (e.key === 'Enter') submitRename(col)
+                              if (e.key === 'Escape') { setRenamingId(null) }
+                            }}
+                            onBlur={() => submitRename(col)}
+                            autoFocus
+                            onClick={e => e.stopPropagation()}
+                          />
+                        ) : (
+                          <div className="text-sm font-medium text-text truncate">{col.name}</div>
+                        )}
                         {col.description && (
                           <div className="text-xs text-text-dim mt-0.5 truncate">{col.description}</div>
                         )}
@@ -130,14 +177,19 @@ export default function CollectionsPane({ collections, onEnter, onDelete, onCrea
                       {col.album_count != null && (
                         <span className="text-xs text-text-dim tabular-nums">{col.album_count}</span>
                       )}
-                      <div onClick={e => e.stopPropagation()}>
-                        {isConfirming ? (
+                      <div onClick={e => e.stopPropagation()} className="relative">
+                        {renamingId === col.id ? null : confirmingId === col.id ? (
                           <>
                             <button className="bg-delete-red border-none text-white cursor-pointer text-xs font-semibold px-1.5 py-0.5 rounded mr-0.5 whitespace-nowrap" aria-label="Confirm delete" onClick={e => handleConfirmDelete(e, col.id)}>Delete</button>
                             <button className="bg-transparent border border-border text-text-dim cursor-pointer text-xs px-1.5 py-0.5 rounded whitespace-nowrap" aria-label="Cancel" onClick={handleCancelDelete}>Cancel</button>
                           </>
+                        ) : menuOpenId === col.id ? (
+                          <div className="flex gap-1">
+                            <button className="bg-transparent border border-border text-text text-xs px-2 py-1 rounded cursor-pointer hover:bg-surface-2" onClick={() => { setMenuOpenId(null); setRenamingId(col.id); setRenameValue(col.name) }}>Rename</button>
+                            <button className="bg-transparent border border-border text-delete-red text-xs px-2 py-1 rounded cursor-pointer hover:bg-surface-2" onClick={e => { setMenuOpenId(null); handleDeleteClick(e, col.id) }}>Delete</button>
+                          </div>
                         ) : (
-                          <button className="bg-transparent border-none text-text-dim cursor-pointer text-lg p-1.5 rounded opacity-0 group-hover:opacity-50 hover:!opacity-100 hover:bg-surface-2 transition-opacity duration-150" aria-label="Delete" onClick={e => handleDeleteClick(e, col.id)}>×</button>
+                          <button className="bg-transparent border-none text-text-dim cursor-pointer text-lg p-1.5 rounded opacity-0 group-hover:opacity-50 hover:!opacity-100 hover:bg-surface-2 transition-opacity duration-150" aria-label="More options" onClick={() => setMenuOpenId(col.id)}>⋯</button>
                         )}
                       </div>
                     </div>

--- a/frontend/src/components/CollectionsPane.test.jsx
+++ b/frontend/src/components/CollectionsPane.test.jsx
@@ -55,32 +55,35 @@ describe('CollectionsPane', () => {
     expect(onEnter).toHaveBeenCalledWith(COLLECTIONS[0])
   })
 
-  it('calls onDelete with collection id when Delete is confirmed (two-click flow)', async () => {
+  it('calls onDelete with collection id when Delete is confirmed (three-click flow)', async () => {
     const onDelete = vi.fn()
     render(
       <CollectionsPane
         collections={COLLECTIONS}
         onEnter={() => {}}
         onDelete={onDelete}
+        onRename={() => {}}
         onFetchAlbums={() => Promise.resolve([])}
       />
     )
-    await userEvent.click(screen.getAllByRole('button', { name: /^delete$/i })[0])
+    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
+    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }))
     await userEvent.click(screen.getByRole('button', { name: /confirm delete/i }))
     expect(onDelete).toHaveBeenCalledWith('col-1')
   })
 
-  it('does not call onEnter when the delete button is clicked', async () => {
+  it('does not call onEnter when the menu button is clicked', async () => {
     const onEnter = vi.fn()
     render(
       <CollectionsPane
         collections={COLLECTIONS}
         onEnter={onEnter}
         onDelete={() => {}}
+        onRename={() => {}}
         onFetchAlbums={() => Promise.resolve([])}
       />
     )
-    await userEvent.click(screen.getAllByRole('button', { name: /delete/i })[0])
+    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
     expect(onEnter).not.toHaveBeenCalled()
   })
 
@@ -261,19 +264,139 @@ describe('CollectionsPane', () => {
     expect(gridEl).not.toBeInTheDocument()
   })
 
-  // --- Delete confirmation ---
+  // --- Three-dot menu ---
 
-  it('delete button shows confirmation on first click', async () => {
+  it('shows a three-dot menu button on each collection row', () => {
     render(
       <CollectionsPane
         collections={COLLECTIONS}
         onEnter={() => {}}
         onDelete={() => {}}
+        onRename={() => {}}
         onFetchAlbums={() => Promise.resolve([])}
       />
     )
-    const deleteBtns = screen.getAllByRole('button', { name: /^delete$/i })
-    await userEvent.click(deleteBtns[0])
+    const menuBtns = screen.getAllByRole('button', { name: /more options/i })
+    expect(menuBtns).toHaveLength(2)
+  })
+
+  it('opens menu with Rename and Delete options on click', async () => {
+    render(
+      <CollectionsPane
+        collections={COLLECTIONS}
+        onEnter={() => {}}
+        onDelete={() => {}}
+        onRename={() => {}}
+        onFetchAlbums={() => Promise.resolve([])}
+      />
+    )
+    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
+    expect(screen.getByRole('button', { name: /^rename$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument()
+  })
+
+  it('enters inline rename mode when Rename is clicked from menu', async () => {
+    render(
+      <CollectionsPane
+        collections={COLLECTIONS}
+        onEnter={() => {}}
+        onDelete={() => {}}
+        onRename={() => {}}
+        onFetchAlbums={() => Promise.resolve([])}
+      />
+    )
+    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
+    await userEvent.click(screen.getByRole('button', { name: /^rename$/i }))
+    expect(screen.getByDisplayValue('Road trip')).toBeInTheDocument()
+  })
+
+  it('calls onRename with new name on Enter', async () => {
+    const onRename = vi.fn()
+    render(
+      <CollectionsPane
+        collections={COLLECTIONS}
+        onEnter={() => {}}
+        onDelete={() => {}}
+        onRename={onRename}
+        onFetchAlbums={() => Promise.resolve([])}
+      />
+    )
+    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
+    await userEvent.click(screen.getByRole('button', { name: /^rename$/i }))
+    const input = screen.getByDisplayValue('Road trip')
+    await userEvent.clear(input)
+    await userEvent.type(input, 'Summer vibes{Enter}')
+    expect(onRename).toHaveBeenCalledWith('col-1', 'Summer vibes')
+  })
+
+  it('cancels rename on Escape without calling onRename', async () => {
+    const onRename = vi.fn()
+    render(
+      <CollectionsPane
+        collections={COLLECTIONS}
+        onEnter={() => {}}
+        onDelete={() => {}}
+        onRename={onRename}
+        onFetchAlbums={() => Promise.resolve([])}
+      />
+    )
+    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
+    await userEvent.click(screen.getByRole('button', { name: /^rename$/i }))
+    await userEvent.keyboard('{Escape}')
+    expect(onRename).not.toHaveBeenCalled()
+    expect(screen.getByText('Road trip')).toBeInTheDocument()
+  })
+
+  it('does not call onRename if name is unchanged', async () => {
+    const onRename = vi.fn()
+    render(
+      <CollectionsPane
+        collections={COLLECTIONS}
+        onEnter={() => {}}
+        onDelete={() => {}}
+        onRename={onRename}
+        onFetchAlbums={() => Promise.resolve([])}
+      />
+    )
+    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
+    await userEvent.click(screen.getByRole('button', { name: /^rename$/i }))
+    await userEvent.keyboard('{Enter}')
+    expect(onRename).not.toHaveBeenCalled()
+  })
+
+  it('does not call onRename if name is empty', async () => {
+    const onRename = vi.fn()
+    render(
+      <CollectionsPane
+        collections={COLLECTIONS}
+        onEnter={() => {}}
+        onDelete={() => {}}
+        onRename={onRename}
+        onFetchAlbums={() => Promise.resolve([])}
+      />
+    )
+    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
+    await userEvent.click(screen.getByRole('button', { name: /^rename$/i }))
+    const input = screen.getByDisplayValue('Road trip')
+    await userEvent.clear(input)
+    await userEvent.keyboard('{Enter}')
+    expect(onRename).not.toHaveBeenCalled()
+  })
+
+  // --- Delete confirmation ---
+
+  it('delete button shows confirmation via menu', async () => {
+    render(
+      <CollectionsPane
+        collections={COLLECTIONS}
+        onEnter={() => {}}
+        onDelete={() => {}}
+        onRename={() => {}}
+        onFetchAlbums={() => Promise.resolve([])}
+      />
+    )
+    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
+    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }))
     expect(screen.getByRole('button', { name: /confirm delete/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
   })
@@ -285,11 +408,12 @@ describe('CollectionsPane', () => {
         collections={COLLECTIONS}
         onEnter={() => {}}
         onDelete={onDelete}
+        onRename={() => {}}
         onFetchAlbums={() => Promise.resolve([])}
       />
     )
-    const deleteBtns = screen.getAllByRole('button', { name: /^delete$/i })
-    await userEvent.click(deleteBtns[0])
+    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
+    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }))
     const confirmBtn = screen.getByRole('button', { name: /confirm delete/i })
     await userEvent.click(confirmBtn)
     expect(onDelete).toHaveBeenCalledWith('col-1')
@@ -302,11 +426,12 @@ describe('CollectionsPane', () => {
         collections={COLLECTIONS}
         onEnter={() => {}}
         onDelete={onDelete}
+        onRename={() => {}}
         onFetchAlbums={() => Promise.resolve([])}
       />
     )
-    const deleteBtns = screen.getAllByRole('button', { name: /^delete$/i })
-    await userEvent.click(deleteBtns[0])
+    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
+    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }))
     const cancelBtn = screen.getByRole('button', { name: /cancel/i })
     await userEvent.click(cancelBtn)
     expect(onDelete).not.toHaveBeenCalled()


### PR DESCRIPTION
## Summary
- Backend: `PATCH /collections/{id}` endpoint for renaming
- Collection detail view: name is now an inline editable input (same pattern as description)
- Collections list: × delete button replaced with ⋯ menu offering Rename and Delete
  - Rename enters inline edit mode on the row
  - Delete keeps existing two-step confirmation
- Optimistic UI updates with rollback on failure

## Test plan
- [x] Backend: 2 new pytest tests (rename + empty name rejection) — 39 total pass
- [x] CollectionDetailHeader: 4 new tests (rename, unchanged, empty, Enter key) — 10 total pass
- [x] CollectionsPane: 7 new + 5 updated tests (menu, rename flow, delete via menu) — 28 total pass
- [x] All 452 frontend + 39 backend tests pass

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)