### PR TITLE
[79] Bypass invite code requirement for signup

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -33,23 +33,32 @@ class StoreSpotifyTokenRequest(BaseModel):
 @router.post("/redeem-invite")
 @limiter.limit("5/15minutes")
 async def redeem_invite(request: Request, body: RedeemInviteRequest):
-    """Validate an invite code and mark it redeemed."""
-    db = get_service_db()
-    result = db.table("invite_codes").select("*").eq("code", body.invite_code).execute()
+    """Validate an invite code and mark it redeemed.
 
-    if not result.data:
-        raise HTTPException(status_code=404, detail="Invite code not found")
-
-    invite = result.data[0]
-    if invite.get("redeemed_at") is not None:
-        raise HTTPException(status_code=400, detail="Invite code already used")
-
-    db.table("invite_codes").update(
-        {
-            "redeemed_at": datetime.now(timezone.utc).isoformat(),
-        }
-    ).eq("code", body.invite_code).execute()
+    BYPASSED: invite code check disabled (issue #79) — always succeeds
+    without touching the database. To re-enable, restore the original
+    validation logic below.
+    """
+    # --- BYPASSED (issue #79): open registration, skip DB validation ---
     return {"message": "Invite code redeemed"}
+
+    # --- Original invite code validation (kept for revertibility) ---
+    # db = get_service_db()
+    # result = db.table("invite_codes").select("*").eq("code", body.invite_code).execute()
+    #
+    # if not result.data:
+    #     raise HTTPException(status_code=404, detail="Invite code not found")
+    #
+    # invite = result.data[0]
+    # if invite.get("redeemed_at") is not None:
+    #     raise HTTPException(status_code=400, detail="Invite code already used")
+    #
+    # db.table("invite_codes").update(
+    #     {
+    #         "redeemed_at": datetime.now(timezone.utc).isoformat(),
+    #     }
+    # ).eq("code", body.invite_code).execute()
+    # return {"message": "Invite code redeemed"}
 
 
 # --- Authenticated endpoints ---

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,6 +1,10 @@
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import (  # HTTPException unused while invite bypass active (issue #79)
+    APIRouter,
+    Depends,
+    Request,
+)
 from pydantic import BaseModel
 from slowapi import Limiter
 from slowapi.util import get_remote_address

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -15,87 +15,33 @@ def test_health():
 
 
 # --- redeem-invite tests ---
+# Original validation tests removed — invite code check bypassed (issue #79).
+# See git history for the original tests if re-enabling.
 
 
-def test_redeem_invite_valid_code():
-    mock_db = MagicMock()
-    # First call: select invite code — returns valid, unredeemed invite
-    invite_row = {
-        "code": "TESTCODE",
-        "redeemed_at": None,
-    }
-    mock_db.table.return_value.select.return_value.eq.return_value.execute.return_value.data = [
-        invite_row
-    ]
-    # update call for marking redeemed
-    mock_db.table.return_value.update.return_value.eq.return_value.execute.return_value = MagicMock()
+# --- redeem-invite bypass tests (issue #79) ---
 
-    with patch("routers.auth.get_service_db", return_value=mock_db):
-        response = client.post(
-            "/auth/redeem-invite",
-            json={"invite_code": "TESTCODE"},
-        )
 
+def test_redeem_invite_bypassed_always_succeeds():
+    """Invite code validation is bypassed — any code should succeed without DB."""
+    response = client.post(
+        "/auth/redeem-invite",
+        json={"invite_code": "ANYTHING"},
+    )
     assert response.status_code == 200
     assert "redeemed" in response.json()["message"].lower()
 
 
-def test_redeem_invite_marks_code_as_used():
+def test_redeem_invite_bypassed_no_db_call():
+    """Bypassed endpoint should not touch the database at all."""
     mock_db = MagicMock()
-    invite_row = {
-        "code": "TESTCODE",
-        "redeemed_at": None,
-    }
-    mock_db.table.return_value.select.return_value.eq.return_value.execute.return_value.data = [
-        invite_row
-    ]
-    mock_db.table.return_value.update.return_value.eq.return_value.execute.return_value = MagicMock()
-
     with patch("routers.auth.get_service_db", return_value=mock_db):
         response = client.post(
             "/auth/redeem-invite",
-            json={"invite_code": "TESTCODE"},
+            json={"invite_code": "ANYTHING"},
         )
-
     assert response.status_code == 200
-    # Verify the update call was made to mark the code as used
-    mock_db.table.return_value.update.assert_called_once()
-    update_arg = mock_db.table.return_value.update.call_args[0][0]
-    assert "redeemed_at" in update_arg
-
-
-def test_redeem_invite_already_used():
-    mock_db = MagicMock()
-    invite_row = {
-        "code": "ABC123",
-        "redeemed_at": "2026-01-01T00:00:00+00:00",
-    }
-    mock_db.table.return_value.select.return_value.eq.return_value.execute.return_value.data = [
-        invite_row
-    ]
-
-    with patch("routers.auth.get_service_db", return_value=mock_db):
-        response = client.post(
-            "/auth/redeem-invite",
-            json={"invite_code": "ABC123"},
-        )
-
-    assert response.status_code == 400
-    assert "already" in response.json()["detail"].lower()
-
-
-def test_redeem_invite_nonexistent_code():
-    mock_db = MagicMock()
-    mock_db.table.return_value.select.return_value.eq.return_value.execute.return_value.data = []
-
-    with patch("routers.auth.get_service_db", return_value=mock_db):
-        response = client.post(
-            "/auth/redeem-invite",
-            json={"invite_code": "BADCODE"},
-        )
-
-    assert response.status_code == 404
-    assert "not found" in response.json()["detail"].lower()
+    mock_db.table.assert_not_called()
 
 
 # --- spotify-token tests ---

--- a/frontend/src/components/SignupScreen.jsx
+++ b/frontend/src/components/SignupScreen.jsx
@@ -3,9 +3,10 @@ import supabase from '../supabaseClient'
 
 const API = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:8000'
 
+// BYPASSED: invite code gate disabled (issue #79) — signup goes straight
+// to Google OAuth without requiring an invite code. Original invite code
+// UI and validation kept commented out for revertibility.
 export default function SignupScreen() {
-  const [inviteCode, setInviteCode] = useState('')
-  const [isReturnUser, setIsReturnUser] = useState(false)
   const [errorMsg, setErrorMsg] = useState('')
   const [loading, setLoading] = useState(false)
 
@@ -14,15 +15,6 @@ export default function SignupScreen() {
     setLoading(true)
     setErrorMsg('')
     try {
-      if (!isReturnUser) {
-        const res = await fetch(`${API}/auth/redeem-invite`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ invite_code: inviteCode }),
-        })
-        const data = await res.json()
-        if (!res.ok) throw new Error(data.detail ?? 'Something went wrong')
-      }
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
         options: { redirectTo: window.location.origin },
@@ -40,21 +32,12 @@ export default function SignupScreen() {
       <h1 className="text-3xl font-bold">Bummer</h1>
       <p className="text-gray-400">the death of shuffle</p>
       <form onSubmit={handleGoogleSignIn} className="flex flex-col gap-4 w-full max-w-sm">
-        {!isReturnUser && (
-          <input type="text" placeholder="Invite code" value={inviteCode}
-            onChange={e => setInviteCode(e.target.value.toUpperCase())} required
-            className="bg-gray-800 rounded-lg px-4 py-2 text-white border border-gray-700 focus:outline-none focus:border-white font-mono tracking-widest" />
-        )}
         {errorMsg && <p className="text-red-400 text-sm">{errorMsg}</p>}
         <button type="submit" disabled={loading}
           className="bg-white text-black font-semibold rounded-lg px-4 py-2 hover:bg-gray-200 disabled:opacity-50">
           {loading ? 'Signing in…' : 'Sign in with Google'}
         </button>
       </form>
-      <button onClick={() => setIsReturnUser(r => !r)}
-        className="text-gray-500 text-sm hover:text-gray-300">
-        {isReturnUser ? 'Have an invite code? Sign up' : 'Already have an account? Sign in'}
-      </button>
     </div>
   )
 }

--- a/frontend/src/components/SignupScreen.jsx
+++ b/frontend/src/components/SignupScreen.jsx
@@ -30,11 +30,11 @@ export default function SignupScreen() {
   return (
     <div className="flex flex-col items-center justify-center min-h-screen gap-6 p-8">
       <h1 className="text-3xl font-bold">Bummer</h1>
-      <p className="text-gray-400">the death of shuffle</p>
-      <form onSubmit={handleGoogleSignIn} className="flex flex-col gap-4 w-full max-w-sm">
+      <p className="text-gray-400">The Death of Shuffle.</p>
+      <form onSubmit={handleGoogleSignIn} className="flex flex-col items-center gap-4">
         {errorMsg && <p className="text-red-400 text-sm">{errorMsg}</p>}
         <button type="submit" disabled={loading}
-          className="bg-white text-black font-semibold rounded-lg px-4 py-2 hover:bg-gray-200 disabled:opacity-50">
+          className="bg-white text-black font-semibold rounded-lg px-6 py-2 hover:bg-gray-200 disabled:opacity-50">
           {loading ? 'Signing in…' : 'Sign in with Google'}
         </button>
       </form>

--- a/frontend/src/components/SignupScreen.test.jsx
+++ b/frontend/src/components/SignupScreen.test.jsx
@@ -12,46 +12,15 @@ import supabase from '../supabaseClient'
 describe('SignupScreen', () => {
   beforeEach(() => vi.clearAllMocks())
 
-  it('renders invite code field and Google sign-in button', () => {
+  it('renders Google sign-in button without invite code field (issue #79)', () => {
     render(<SignupScreen />)
-    expect(screen.getByPlaceholderText(/invite code/i)).toBeInTheDocument()
+    expect(screen.queryByPlaceholderText(/invite code/i)).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: /sign in with google/i })).toBeInTheDocument()
   })
 
-  it('first-time signup: validates invite code then calls signInWithOAuth', async () => {
-    fetch.mockResolvedValueOnce({ ok: true, json: async () => ({ message: 'Invite redeemed' }) })
+  it('signup calls signInWithOAuth directly without redeem-invite (issue #79)', async () => {
     supabase.auth.signInWithOAuth.mockResolvedValueOnce({ error: null })
     render(<SignupScreen />)
-    fireEvent.change(screen.getByPlaceholderText(/invite code/i), { target: { value: 'CODE123' } })
-    fireEvent.click(screen.getByRole('button', { name: /sign in with google/i }))
-    await waitFor(() => expect(fetch).toHaveBeenCalledWith(
-      expect.stringContaining('/auth/redeem-invite'),
-      expect.objectContaining({ method: 'POST' })
-    ))
-    await waitFor(() => expect(supabase.auth.signInWithOAuth).toHaveBeenCalledWith(
-      expect.objectContaining({
-        provider: 'google',
-        options: expect.objectContaining({ redirectTo: window.location.origin }),
-      })
-    ))
-  })
-
-  it('first-time signup: blocks Google OAuth if invite code invalid', async () => {
-    fetch.mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({ detail: 'Invite code not found' }),
-    })
-    render(<SignupScreen />)
-    fireEvent.change(screen.getByPlaceholderText(/invite code/i), { target: { value: 'BADCODE' } })
-    fireEvent.click(screen.getByRole('button', { name: /sign in with google/i }))
-    await waitFor(() => expect(screen.getByText(/not found/i)).toBeInTheDocument())
-    expect(supabase.auth.signInWithOAuth).not.toHaveBeenCalled()
-  })
-
-  it('return login: skips invite validation and calls signInWithOAuth directly', async () => {
-    supabase.auth.signInWithOAuth.mockResolvedValueOnce({ error: null })
-    render(<SignupScreen />)
-    fireEvent.click(screen.getByText(/already have an account/i))
     fireEvent.click(screen.getByRole('button', { name: /sign in with google/i }))
     await waitFor(() => expect(supabase.auth.signInWithOAuth).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -61,4 +30,7 @@ describe('SignupScreen', () => {
     ))
     expect(fetch).not.toHaveBeenCalled()
   })
+
+  // Original invite code validation tests removed — bypassed (issue #79).
+  // See git history for original tests if re-enabling.
 })


### PR DESCRIPTION
## Summary
- Short-circuit `redeem-invite` endpoint — always returns success without DB calls (original logic commented out for revertibility)
- Remove invite code input and new/returning user toggle from `SignupScreen` — signup goes straight to Google OAuth
- Update tests: replace invite validation tests with bypass-specific tests

Closes #79

## Test plan
- [x] Backend: 210 tests passing (`pytest`)
- [x] Frontend: 467 tests passing (`vitest`)
- [ ] Verify preview deploy signup flow works without invite code
- [ ] Verify prod deploy after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)