### PR TITLE
Fix collections view scroll on mobile [99]

### DIFF
--- a/frontend/src/components/CollectionsPane.jsx
+++ b/frontend/src/components/CollectionsPane.jsx
@@ -272,7 +272,7 @@ export default function CollectionsPane({ collections, onEnter, onDelete, onCrea
   }
 
   const rowList = (
-    <div className="flex-1 overflow-hidden">
+    <div className="flex-1 overflow-y-auto">
       {collections.map(col => renderRow(col))}
     </div>
   )

--- a/frontend/src/components/CollectionsPane.test.jsx
+++ b/frontend/src/components/CollectionsPane.test.jsx
@@ -241,6 +241,21 @@ describe('CollectionsPane', () => {
     expect(fixedHeightEl).toBeInTheDocument()
   })
 
+  it('collections list container allows vertical scrolling', () => {
+    render(
+      <CollectionsPane
+        collections={COLLECTIONS}
+        onEnter={() => {}}
+        onDelete={() => {}}
+        onFetchAlbums={() => Promise.resolve([])}
+      />
+    )
+    const firstRow = screen.getByText('Road trip').closest('[data-testid="collection-row"]')
+    const listContainer = firstRow.parentElement
+    expect(listContainer.className).toContain('overflow-y-auto')
+    expect(listContainer.className).not.toContain('overflow-hidden')
+  })
+
   it('does not use a multi-column grid layout', () => {
     render(
       <CollectionsPane


### PR DESCRIPTION
## Summary
- Collections list container had `overflow-hidden`, preventing scroll on mobile when collections exceeded viewport
- Changed to `overflow-y-auto` so collections list scrolls normally

Closes #99

## Test plan
- [x] Added test verifying container has `overflow-y-auto` class
- [x] All 495 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)