### PR TITLE
[84] Fix stale digest and broken history pagination

### DIFF
--- a/backend/routers/digest.py
+++ b/backend/routers/digest.py
@@ -384,7 +384,7 @@ def ensure_snapshot(
 
     # Check if a snapshot already exists for today
     existing = (
-        db.table("library_snapshots").select("*").eq("snapshot_date", today).execute()
+        db.table("library_snapshots").select("*").eq("snapshot_date", today).eq("user_id", user_id).execute()
     )
     if existing.data:
         snap = existing.data[0]

--- a/backend/routers/digest.py
+++ b/backend/routers/digest.py
@@ -384,7 +384,11 @@ def ensure_snapshot(
 
     # Check if a snapshot already exists for today
     existing = (
-        db.table("library_snapshots").select("*").eq("snapshot_date", today).eq("user_id", user_id).execute()
+        db.table("library_snapshots")
+        .select("*")
+        .eq("snapshot_date", today)
+        .eq("user_id", user_id)
+        .execute()
     )
     if existing.data:
         snap = existing.data[0]

--- a/backend/tests/test_digest.py
+++ b/backend/tests/test_digest.py
@@ -285,9 +285,9 @@ def test_ensure_snapshot_creates_when_none_exists(mock_date, mock_cache):
         {"service_id": "a2", "name": "Album2", "artists": ["Y"], "image_url": None},
     ]
     db = MagicMock()
-    # No existing snapshot for today
-    db.table.return_value.select.return_value.eq.return_value.execute.return_value = (
-        MagicMock(data=[])
+    # No existing snapshot for today (.eq(snapshot_date).eq(user_id).execute())
+    db.table.return_value.select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[]
     )
     setup_overrides(db=db)
     try:
@@ -317,8 +317,8 @@ def test_ensure_snapshot_skips_when_already_exists(mock_date, mock_cache):
         "total": 2,
     }
     db = MagicMock()
-    db.table.return_value.select.return_value.eq.return_value.execute.return_value = (
-        MagicMock(data=[existing_snapshot])
+    db.table.return_value.select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[existing_snapshot]
     )
     setup_overrides(db=db)
     try:
@@ -343,9 +343,9 @@ def test_ensure_snapshot_returns_503_when_cache_empty(mock_date, mock_cache):
     mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
     mock_cache.return_value = []
     db = MagicMock()
-    # No existing snapshot
-    db.table.return_value.select.return_value.eq.return_value.execute.return_value = (
-        MagicMock(data=[])
+    # No existing snapshot (.eq(snapshot_date).eq(user_id).execute())
+    db.table.return_value.select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[]
     )
     setup_overrides(db=db)
     try:

--- a/frontend/src/components/DigestView.jsx
+++ b/frontend/src/components/DigestView.jsx
@@ -38,7 +38,7 @@ function ChangesSection({ onPlay, session }) {
   function handleLoadMore() {
     if (!nextCursor || loadingMore) return
     setLoadingMore(true)
-    apiFetch(`/digest/changelog?before=${nextCursor}`, {}, session)
+    apiFetch(`/digest/changelog?before=${encodeURIComponent(nextCursor)}`, {}, session)
       .then(res => {
         if (!res.ok) throw new Error('Failed to load more')
         return res.json()
@@ -132,7 +132,7 @@ function HistorySection({ onPlay, session }) {
   function handleLoadMore() {
     if (!nextCursor || loadingMore) return
     setLoadingMore(true)
-    apiFetch(`/digest/history?before=${nextCursor}`, {}, session)
+    apiFetch(`/digest/history?before=${encodeURIComponent(nextCursor)}`, {}, session)
       .then(res => {
         if (!res.ok) throw new Error('Failed to load more')
         return res.json()

--- a/supabase/migrations/20260419000000_fix_snapshot_unique_constraint.sql
+++ b/supabase/migrations/20260419000000_fix_snapshot_unique_constraint.sql
@@ -1,0 +1,4 @@
+-- Fix: unique constraint must match the upsert on_conflict columns (snapshot_date, user_id)
+-- Old: UNIQUE(snapshot_date) — prevents multi-user snapshots and doesn't match on_conflict
+ALTER TABLE public.library_snapshots DROP CONSTRAINT library_snapshots_snapshot_date_key;
+ALTER TABLE public.library_snapshots ADD CONSTRAINT library_snapshots_snapshot_date_user_id_key UNIQUE (snapshot_date, user_id);


### PR DESCRIPTION
## Summary
- Fix DB unique constraint mismatch: `UNIQUE(snapshot_date)` → `UNIQUE(snapshot_date, user_id)` so upsert `on_conflict` matches and snapshots actually get created
- Add explicit `user_id` filter in `ensure_snapshot` existing-check query
- URL-encode pagination cursors in DigestView to prevent `+` in timezone offsets breaking datetime parsing

## Root causes
1. **Stale digest**: PostgREST rejected snapshot upserts because `on_conflict="snapshot_date,user_id"` had no matching unique constraint — snapshots silently failed to create
2. **Broken "Load more" on history**: `+00:00` in cursor timestamps was decoded as a space in URL query strings, causing backend datetime parsing to fail

## Test plan
- [ ] Apply migration to prod via `supabase db push` BEFORE merging (previews share prod DB)
- [ ] Verify cron snapshot runs successfully (check Vercel cron logs after next 6AM UTC run)
- [ ] Open digest tab — should show recent library changes
- [ ] Click "Load more" on listening history — should load additional entries

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)