### PR TITLE
[116] Add Open Graph meta tags for link previews

### DIFF
--- a/frontend/landing.html
+++ b/frontend/landing.html
@@ -4,6 +4,17 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#111111" />
+    <!-- Open Graph -->
+    <meta property="og:title" content="Bummer" />
+    <meta property="og:description" content="A personal music library manager built on Spotify" />
+    <meta property="og:image" content="https://thedeathofshuffle.com/screenshots/home.png" />
+    <meta property="og:url" content="https://thedeathofshuffle.com" />
+    <meta property="og:type" content="website" />
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Bummer" />
+    <meta name="twitter:description" content="A personal music library manager built on Spotify" />
+    <meta name="twitter:image" content="https://thedeathofshuffle.com/screenshots/home.png" />
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🐣</text></svg>" />
     <title>Bummer</title>
   </head>


### PR DESCRIPTION
## Summary
- Add `og:title`, `og:description`, `og:image`, `og:url`, `og:type` meta tags to `landing.html`
- Add `twitter:card` (summary_large_image), `twitter:title`, `twitter:description`, `twitter:image`
- Uses existing `/screenshots/home.png` as the preview image
- Prod URL: `https://thedeathofshuffle.com`

Closes #116

## Test plan
- [ ] Deploy preview and test link preview in iMessage/Slack/Discord
- [ ] Validate with https://www.opengraph.xyz/ or Facebook Sharing Debugger

🤖 Generated with [Claude Code](https://claude.com/claude-code)