### PR TITLE
Hide scrollbars on home page columns [110]

### DIFF
--- a/frontend/src/components/HomePage.jsx
+++ b/frontend/src/components/HomePage.jsx
@@ -75,7 +75,7 @@ export default function HomePage({ onPlay, session }) {
           activeTab={activeTab}
           onTabChange={setActiveTab}
         />
-        <div className="flex-1 overflow-y-auto">
+        <div className="flex-1 overflow-y-auto prompt-row-scroll">
           <AlbumList albums={sections[activeTab]} onPlay={onPlay} />
         </div>
       </div>
@@ -87,7 +87,7 @@ export default function HomePage({ onPlay, session }) {
       {TABS.map((tab, i) => (
         <div key={tab.id} className="flex-1 flex flex-col">
           <div className="px-4 py-2 text-sm font-bold tracking-wider uppercase text-text text-center flex-shrink-0 flex items-center justify-center" style={{ height: 40 }}>{tab.label}</div>
-          <div className="flex-1 overflow-y-auto">
+          <div className="flex-1 overflow-y-auto prompt-row-scroll">
             <AlbumList albums={sections[tab.id]} onPlay={onPlay} />
           </div>
         </div>

--- a/frontend/src/components/HomePage.test.jsx
+++ b/frontend/src/components/HomePage.test.jsx
@@ -131,4 +131,28 @@ describe('HomePage', () => {
     render(<HomePage onPlay={() => {}} />)
     expect(screen.getByText(/loading/i)).toBeInTheDocument()
   })
+
+  it('desktop column scroll containers have prompt-row-scroll class', async () => {
+    useIsMobile.mockReturnValue(false)
+    const { container } = render(<HomePage onPlay={() => {}} />)
+    await waitFor(() => {
+      expect(screen.getByText('Recently Played')).toBeInTheDocument()
+    })
+    const scrollContainers = container.querySelectorAll('.overflow-y-auto')
+    expect(scrollContainers).toHaveLength(4)
+    scrollContainers.forEach(el => {
+      expect(el.classList.contains('prompt-row-scroll')).toBe(true)
+    })
+  })
+
+  it('mobile scroll container has prompt-row-scroll class', async () => {
+    useIsMobile.mockReturnValue(true)
+    const { container } = render(<HomePage onPlay={() => {}} />)
+    await waitFor(() => {
+      expect(screen.getByAltText('Today Album')).toBeInTheDocument()
+    })
+    const scrollContainers = container.querySelectorAll('.overflow-y-auto')
+    expect(scrollContainers).toHaveLength(1)
+    expect(scrollContainers[0].classList.contains('prompt-row-scroll')).toBe(true)
+  })
 })


### PR DESCRIPTION
## Summary
- Add `prompt-row-scroll` class to mobile and desktop scroll containers in HomePage
- Reuses existing scrollbar-hiding CSS utility (Firefox, Chrome, Safari, Edge)
- Scrollbar space preserved — no layout shift

Closes #110

## Test plan
- [x] Added tests verifying `prompt-row-scroll` class on desktop (4 columns) and mobile (1 container)
- [x] All 513 tests pass
- [ ] Visual check in light mode on preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)