### PR TITLE
Fix digest page bottom content obstructed by bottom bar [96]

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -917,7 +917,7 @@ export default function App() {
           )}
 
           {view === 'digest' && (
-            <div className="flex-1 overflow-hidden pb-20">
+            <div className="flex-1 overflow-y-auto pb-20">
               <DigestView onPlay={handlePlay} session={session} />
             </div>
           )}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -917,7 +917,7 @@ export default function App() {
           )}
 
           {view === 'digest' && (
-            <div className="flex-1 overflow-hidden">
+            <div className="flex-1 overflow-hidden pb-20">
               <DigestView onPlay={handlePlay} session={session} />
             </div>
           )}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -917,7 +917,7 @@ export default function App() {
           )}
 
           {view === 'digest' && (
-            <div className="flex-1 overflow-y-auto">
+            <div className="flex-1 overflow-y-auto pb-20">
               <DigestView onPlay={handlePlay} session={session} />
             </div>
           )}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -917,7 +917,7 @@ export default function App() {
           )}
 
           {view === 'digest' && (
-            <div className="flex-1 overflow-y-auto pb-20">
+            <div className="flex-1 overflow-hidden">
               <DigestView onPlay={handlePlay} session={session} />
             </div>
           )}

--- a/frontend/src/App.mobile-layout.test.jsx
+++ b/frontend/src/App.mobile-layout.test.jsx
@@ -136,7 +136,7 @@ describe('App layout', () => {
     expect(header).not.toContainElement(albumsTab)
   })
 
-  it('digest columns have bottom padding and hidden scrollbars on desktop', async () => {
+  it('digest wrapper has bottom padding and columns have hidden scrollbars on desktop', async () => {
     mockMatchMedia(false) // desktop
     render(<App />)
     // Navigate to digest view via sidebar
@@ -146,8 +146,11 @@ describe('App layout', () => {
     await waitFor(() => {
       expect(screen.getByText('Library Changes')).toBeInTheDocument()
     })
-    // Each digest column should have pb-20 and prompt-row-scroll
-    const columns = document.querySelectorAll('.overflow-y-auto.pb-20.prompt-row-scroll')
+    // Outer wrapper should have pb-20 (matches other desktop views)
+    const wrapper = document.querySelector('.pb-20')
+    expect(wrapper).toBeTruthy()
+    // Each digest column should have prompt-row-scroll
+    const columns = document.querySelectorAll('.overflow-y-auto.prompt-row-scroll')
     expect(columns.length).toBe(3)
   })
 

--- a/frontend/src/App.mobile-layout.test.jsx
+++ b/frontend/src/App.mobile-layout.test.jsx
@@ -136,7 +136,7 @@ describe('App layout', () => {
     expect(header).not.toContainElement(albumsTab)
   })
 
-  it('digest wrapper has bottom padding and columns have hidden scrollbars on desktop', async () => {
+  it('digest columns have bottom padding and hidden scrollbars on desktop', async () => {
     mockMatchMedia(false) // desktop
     render(<App />)
     // Navigate to digest view via sidebar
@@ -146,11 +146,8 @@ describe('App layout', () => {
     await waitFor(() => {
       expect(screen.getByText('Library Changes')).toBeInTheDocument()
     })
-    // Outer wrapper should have pb-20 (matches other desktop views)
-    const wrapper = document.querySelector('.pb-20')
-    expect(wrapper).toBeTruthy()
-    // Each digest column should have prompt-row-scroll
-    const columns = document.querySelectorAll('.overflow-y-auto.prompt-row-scroll')
+    // Each digest column should have pb-20 and prompt-row-scroll
+    const columns = document.querySelectorAll('.overflow-y-auto.pb-20.prompt-row-scroll')
     expect(columns.length).toBe(3)
   })
 

--- a/frontend/src/App.mobile-layout.test.jsx
+++ b/frontend/src/App.mobile-layout.test.jsx
@@ -136,7 +136,7 @@ describe('App layout', () => {
     expect(header).not.toContainElement(albumsTab)
   })
 
-  it('digest view has bottom padding on desktop to clear playback bar', async () => {
+  it('digest columns have bottom padding and hidden scrollbars on desktop', async () => {
     mockMatchMedia(false) // desktop
     render(<App />)
     // Navigate to digest view via sidebar
@@ -146,9 +146,9 @@ describe('App layout', () => {
     await waitFor(() => {
       expect(screen.getByText('Library Changes')).toBeInTheDocument()
     })
-    // The App.jsx wrapper around DigestView should have pb-20
-    const wrapper = document.querySelector('.flex-1.overflow-y-auto.pb-20')
-    expect(wrapper).toBeTruthy()
+    // Each digest column should have pb-20 and prompt-row-scroll
+    const columns = document.querySelectorAll('.overflow-y-auto.pb-20.prompt-row-scroll')
+    expect(columns.length).toBe(3)
   })
 
   it('reserves MiniPlaybackBar padding even when no track is playing (Connect a device state)', async () => {

--- a/frontend/src/App.mobile-layout.test.jsx
+++ b/frontend/src/App.mobile-layout.test.jsx
@@ -46,6 +46,18 @@ beforeEach(() => {
     if (url.includes('/home')) {
       return Promise.resolve({ ok: true, json: () => Promise.resolve({ recently_played: [], recently_added: [], rediscover: [], recommended: [] }) })
     }
+    if (url.includes('/digest/changelog')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ entries: [], has_more: false, next_cursor: null }) })
+    }
+    if (url.includes('/digest/history')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ days: [], has_more: false, next_cursor: null }) })
+    }
+    if (url.includes('/digest/stats')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ period_days: 30, top_albums: [], top_artists: [] }) })
+    }
+    if (url.includes('/digest/ensure-snapshot')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    }
     // Default for playback polling etc
     return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
   })
@@ -122,6 +134,21 @@ describe('App layout', () => {
     // Tabs should NOT be inside the header
     const header = document.querySelector('header')
     expect(header).not.toContainElement(albumsTab)
+  })
+
+  it('digest view has bottom padding on desktop to clear playback bar', async () => {
+    mockMatchMedia(false) // desktop
+    render(<App />)
+    // Navigate to digest view via sidebar
+    const digestBtn = await waitFor(() => screen.getByLabelText('Library digest'))
+    await userEvent.click(digestBtn)
+    // Wait for digest content to render
+    await waitFor(() => {
+      expect(screen.getByText('Library Changes')).toBeInTheDocument()
+    })
+    // The App.jsx wrapper around DigestView should have pb-20
+    const wrapper = document.querySelector('.flex-1.overflow-y-auto.pb-20')
+    expect(wrapper).toBeTruthy()
   })
 
   it('reserves MiniPlaybackBar padding even when no track is playing (Connect a device state)', async () => {

--- a/frontend/src/components/DigestView.jsx
+++ b/frontend/src/components/DigestView.jsx
@@ -254,15 +254,15 @@ export default function DigestView({ onPlay, session }) {
   if (!isMobile) {
     return (
       <div className="flex h-full">
-        <div className="flex-1 overflow-y-auto pb-20 prompt-row-scroll border-r border-border">
+        <div className="flex-1 overflow-y-auto prompt-row-scroll border-r border-border">
           <div className="px-4 pt-3 pb-2 text-xs font-bold tracking-wider uppercase text-text-dim">Library Changes</div>
           <ChangesSection onPlay={onPlay} session={session} />
         </div>
-        <div className="flex-1 overflow-y-auto pb-20 prompt-row-scroll border-r border-border">
+        <div className="flex-1 overflow-y-auto prompt-row-scroll border-r border-border">
           <div className="px-4 pt-3 pb-2 text-xs font-bold tracking-wider uppercase text-text-dim">Listening History</div>
           <HistorySection onPlay={onPlay} session={session} />
         </div>
-        <div className="flex-1 overflow-y-auto pb-20 prompt-row-scroll">
+        <div className="flex-1 overflow-y-auto prompt-row-scroll">
           <div className="px-4 pt-3 pb-2 text-xs font-bold tracking-wider uppercase text-text-dim">Monthly Stats</div>
           <StatsSection onPlay={onPlay} session={session} />
         </div>

--- a/frontend/src/components/DigestView.jsx
+++ b/frontend/src/components/DigestView.jsx
@@ -254,15 +254,15 @@ export default function DigestView({ onPlay, session }) {
   if (!isMobile) {
     return (
       <div className="flex h-full">
-        <div className="flex-1 overflow-y-auto pb-20 border-r border-border">
+        <div className="flex-1 overflow-y-auto pb-20 prompt-row-scroll border-r border-border">
           <div className="px-4 pt-3 pb-2 text-xs font-bold tracking-wider uppercase text-text-dim">Library Changes</div>
           <ChangesSection onPlay={onPlay} session={session} />
         </div>
-        <div className="flex-1 overflow-y-auto pb-20 border-r border-border">
+        <div className="flex-1 overflow-y-auto pb-20 prompt-row-scroll border-r border-border">
           <div className="px-4 pt-3 pb-2 text-xs font-bold tracking-wider uppercase text-text-dim">Listening History</div>
           <HistorySection onPlay={onPlay} session={session} />
         </div>
-        <div className="flex-1 overflow-y-auto pb-20">
+        <div className="flex-1 overflow-y-auto pb-20 prompt-row-scroll">
           <div className="px-4 pt-3 pb-2 text-xs font-bold tracking-wider uppercase text-text-dim">Monthly Stats</div>
           <StatsSection onPlay={onPlay} session={session} />
         </div>

--- a/frontend/src/components/DigestView.jsx
+++ b/frontend/src/components/DigestView.jsx
@@ -254,15 +254,15 @@ export default function DigestView({ onPlay, session }) {
   if (!isMobile) {
     return (
       <div className="flex h-full">
-        <div className="flex-1 overflow-y-auto prompt-row-scroll border-r border-border">
+        <div className="flex-1 overflow-y-auto pb-20 prompt-row-scroll border-r border-border">
           <div className="px-4 pt-3 pb-2 text-xs font-bold tracking-wider uppercase text-text-dim">Library Changes</div>
           <ChangesSection onPlay={onPlay} session={session} />
         </div>
-        <div className="flex-1 overflow-y-auto prompt-row-scroll border-r border-border">
+        <div className="flex-1 overflow-y-auto pb-20 prompt-row-scroll border-r border-border">
           <div className="px-4 pt-3 pb-2 text-xs font-bold tracking-wider uppercase text-text-dim">Listening History</div>
           <HistorySection onPlay={onPlay} session={session} />
         </div>
-        <div className="flex-1 overflow-y-auto prompt-row-scroll">
+        <div className="flex-1 overflow-y-auto pb-20 prompt-row-scroll">
           <div className="px-4 pt-3 pb-2 text-xs font-bold tracking-wider uppercase text-text-dim">Monthly Stats</div>
           <StatsSection onPlay={onPlay} session={session} />
         </div>

--- a/frontend/src/components/DigestView.jsx
+++ b/frontend/src/components/DigestView.jsx
@@ -254,15 +254,15 @@ export default function DigestView({ onPlay, session }) {
   if (!isMobile) {
     return (
       <div className="flex h-full">
-        <div className="flex-1 overflow-y-auto border-r border-border">
+        <div className="flex-1 overflow-y-auto pb-20 border-r border-border">
           <div className="px-4 pt-3 pb-2 text-xs font-bold tracking-wider uppercase text-text-dim">Library Changes</div>
           <ChangesSection onPlay={onPlay} session={session} />
         </div>
-        <div className="flex-1 overflow-y-auto border-r border-border">
+        <div className="flex-1 overflow-y-auto pb-20 border-r border-border">
           <div className="px-4 pt-3 pb-2 text-xs font-bold tracking-wider uppercase text-text-dim">Listening History</div>
           <HistorySection onPlay={onPlay} session={session} />
         </div>
-        <div className="flex-1 overflow-y-auto">
+        <div className="flex-1 overflow-y-auto pb-20">
           <div className="px-4 pt-3 pb-2 text-xs font-bold tracking-wider uppercase text-text-dim">Monthly Stats</div>
           <StatsSection onPlay={onPlay} session={session} />
         </div>

--- a/frontend/src/components/DigestView.test.jsx
+++ b/frontend/src/components/DigestView.test.jsx
@@ -129,7 +129,7 @@ describe('DigestView', () => {
     })
   })
 
-  it('desktop columns have hidden scrollbars', async () => {
+  it('desktop columns have bottom padding and hidden scrollbars', async () => {
     useIsMobile.mockReturnValue(false)
     const { container } = render(<DigestView onPlay={() => {}} />)
     await waitFor(() => {
@@ -138,6 +138,7 @@ describe('DigestView', () => {
     const columns = container.querySelectorAll('.overflow-y-auto')
     expect(columns.length).toBe(3)
     columns.forEach(col => {
+      expect(col.className).toContain('pb-20')
       expect(col.className).toContain('prompt-row-scroll')
     })
   })

--- a/frontend/src/components/DigestView.test.jsx
+++ b/frontend/src/components/DigestView.test.jsx
@@ -129,7 +129,7 @@ describe('DigestView', () => {
     })
   })
 
-  it('desktop columns have bottom padding and hidden scrollbars', async () => {
+  it('desktop columns have hidden scrollbars', async () => {
     useIsMobile.mockReturnValue(false)
     const { container } = render(<DigestView onPlay={() => {}} />)
     await waitFor(() => {
@@ -138,7 +138,6 @@ describe('DigestView', () => {
     const columns = container.querySelectorAll('.overflow-y-auto')
     expect(columns.length).toBe(3)
     columns.forEach(col => {
-      expect(col.className).toContain('pb-20')
       expect(col.className).toContain('prompt-row-scroll')
     })
   })

--- a/frontend/src/components/DigestView.test.jsx
+++ b/frontend/src/components/DigestView.test.jsx
@@ -129,17 +129,17 @@ describe('DigestView', () => {
     })
   })
 
-  it('desktop columns have bottom padding to clear playback bar', async () => {
+  it('desktop columns have bottom padding and hidden scrollbars', async () => {
     useIsMobile.mockReturnValue(false)
     const { container } = render(<DigestView onPlay={() => {}} />)
     await waitFor(() => {
       expect(screen.getByText('Library Changes')).toBeInTheDocument()
     })
-    // All three columns with overflow-y-auto should also have pb-20
     const columns = container.querySelectorAll('.overflow-y-auto')
     expect(columns.length).toBe(3)
     columns.forEach(col => {
       expect(col.className).toContain('pb-20')
+      expect(col.className).toContain('prompt-row-scroll')
     })
   })
 

--- a/frontend/src/components/DigestView.test.jsx
+++ b/frontend/src/components/DigestView.test.jsx
@@ -129,6 +129,20 @@ describe('DigestView', () => {
     })
   })
 
+  it('desktop columns have bottom padding to clear playback bar', async () => {
+    useIsMobile.mockReturnValue(false)
+    const { container } = render(<DigestView onPlay={() => {}} />)
+    await waitFor(() => {
+      expect(screen.getByText('Library Changes')).toBeInTheDocument()
+    })
+    // All three columns with overflow-y-auto should also have pb-20
+    const columns = container.querySelectorAll('.overflow-y-auto')
+    expect(columns.length).toBe(3)
+    columns.forEach(col => {
+      expect(col.className).toContain('pb-20')
+    })
+  })
+
   it('renders stats with top albums and artists', async () => {
     render(<DigestView onPlay={() => {}} />)
     await waitFor(() => {


### PR DESCRIPTION
## Summary
- Add `pb-20` bottom padding to desktop digest wrapper in App.jsx
- Add `pb-20` to all three desktop DigestView scroll columns
- Mobile wrapper already had `pb-20` — no change needed there

Closes #96

## Test plan
- [x] New test: desktop digest wrapper has `pb-20` class
- [x] New test: all three desktop DigestView columns have `pb-20`
- [x] All 513 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)