### PR TITLE
Fix library view reset and add context-aware now-playing [87]

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -54,6 +54,12 @@ export default function App() {
     try { localStorage.setItem('library_view', val) } catch {}
     setLibrarySubViewRaw(val)
   }
+  // Reset library sub-view to albums when navigating away from library
+  useEffect(() => {
+    if (view !== 'library') {
+      setLibrarySubView('albums')
+    }
+  }, [view])
   const [playingId, setPlayingId] = useState(null)
   const [paneOpen, setPaneOpen] = useState(false)
 
@@ -495,16 +501,13 @@ export default function App() {
   function handleFocusAlbum(albumId) {
     if (view !== 'library') {
       setView('library')
-      setTimeout(() => {
-        const el = document.getElementById(`row-album-${albumId}`)
-        el?.focus()
-        el?.scrollIntoView({ block: 'center' })
-      }, 0)
-    } else {
+    }
+    setLibrarySubView('albums')
+    setTimeout(() => {
       const el = document.getElementById(`row-album-${albumId}`)
       el?.focus()
       el?.scrollIntoView({ block: 'center' })
-    }
+    }, 0)
   }
 
   /**

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -91,6 +91,10 @@ export default function App() {
   const [collectionPlayback, setCollectionPlayback] = useState(null)
   const collectionPlaybackRef = useRef(null)
   collectionPlaybackRef.current = collectionPlayback
+  // Track which view the user was on when they started playback
+  const [playbackOrigin, setPlaybackOrigin] = useState(null)
+  const viewRef = useRef(view)
+  viewRef.current = view
   const isInCollection = view !== 'home' && view !== 'library' && view !== 'collections' && view !== 'digest' && view !== 'settings'
   const artistCount = useMemo(() => {
     const artists = new Set()
@@ -423,6 +427,7 @@ export default function App() {
         }
       }
       if (!err) {
+        setPlaybackOrigin(viewRef.current)
         apiFetch('/home/history/log', {
           method: 'POST',
           body: JSON.stringify({ album_id: albumId }),
@@ -499,6 +504,12 @@ export default function App() {
   }
 
   function handleFocusAlbum(albumId) {
+    // If playback started from a collection, navigate back to that collection
+    if (playbackOrigin && typeof playbackOrigin === 'object' && playbackOrigin.id) {
+      setView(playbackOrigin)
+      return
+    }
+    // Otherwise navigate to library albums view
     if (view !== 'library') {
       setView('library')
     }

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -650,7 +650,7 @@ describe('App — localStorage cache + syncing pulse', () => {
     clearLocalStorageCache()
   })
 
-  it('librarySubView persists when navigating away and back', async () => {
+  it('librarySubView resets to albums when navigating away and back', async () => {
     window.matchMedia = vi.fn().mockImplementation(query => ({
       matches: false,
       media: query,
@@ -684,9 +684,9 @@ describe('App — localStorage cache + syncing pulse', () => {
     // Navigate away to Collections
     await userEvent.click(screen.getByRole('button', { name: /collections/i }))
 
-    // Navigate back to Library — should still be on Artists
+    // Navigate back to Library — should reset to Albums (not persist Artists)
     await userEvent.click(screen.getByRole('button', { name: /^library( syncing)?$/i }))
-    expect(await screen.findByTestId('artist-row-Test Artist')).toBeInTheDocument()
+    expect(screen.queryByTestId('artist-row-Test Artist')).not.toBeInTheDocument()
 
     clearLocalStorageCache()
   })
@@ -732,7 +732,7 @@ describe('App — localStorage cache + syncing pulse', () => {
     clearLocalStorageCache()
   })
 
-  it('reads library_view from localStorage on mount and restores artists sub-view', async () => {
+  it('library always opens in albums view regardless of localStorage', async () => {
     window.matchMedia = vi.fn().mockImplementation(query => ({
       matches: false,
       media: query,
@@ -760,9 +760,10 @@ describe('App — localStorage cache + syncing pulse', () => {
 
     render(<App />)
 
-    // Navigate to Library — should open directly on Artists sub-view (restored from localStorage)
+    // Navigate to Library — should open in Albums view (localStorage 'artists' is overridden)
     await userEvent.click(await screen.findByRole('button', { name: /^library( syncing)?$/i }))
-    expect(await screen.findByTestId('artist-row-Test Artist')).toBeInTheDocument()
+    // Should NOT see artist row — sub-view resets to albums regardless of localStorage
+    expect(screen.queryByTestId('artist-row-Test Artist')).not.toBeInTheDocument()
 
     clearLocalStorageCache()
     localStorage.removeItem('library_view')


### PR DESCRIPTION
## Summary
- Library sub-view (albums/artists) now resets to albums when navigating away, fixing the bug where the now-playing button appeared broken on the artists tab
- Now-playing album art click navigates back to the playback origin context (collection or library)

Closes #87

## Test plan
- [x] Navigate to Library → switch to Artists tab → navigate to Collections → navigate back to Library → should show Albums (not Artists)
- [x] Play an album from Library → tap now-playing album art → should navigate to Library and scroll to album
- [x] Play an album from a Collection → tap now-playing album art → should navigate back to that Collection
- [ ] Verify all 511 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)