### PR TITLE
Fix BulkAddBar persisting when navigating away from library [122]

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -272,6 +272,14 @@ export default function App() {
     setCollectionCreateName('')
   }, [view])
 
+  // Clear album selection when navigating away from library
+  useEffect(() => {
+    if (view !== 'library') {
+      setSelectedAlbumIds([])
+      setPickerAlbumIds(null)
+    }
+  }, [view])
+
   // Escape key clears selection
   useEffect(() => {
     function handleKeyDown(e) {

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1689,6 +1689,61 @@ describe('App — listen counts', () => {
   })
 })
 
+describe('App — BulkAddBar clears on view change', () => {
+  it('clears selected albums and hides BulkAddBar when navigating away from library', async () => {
+    window.matchMedia = vi.fn().mockImplementation(query => ({
+      matches: false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+
+    const TEST_ALBUMS = [
+      { service_id: 'sel-1', name: 'Selectable Album', artists: ['Artist'], image_url: null, release_date: '2020', total_tracks: 10, added_at: '2021-01-01T00:00:00Z' },
+    ]
+    seedLocalStorageCache(TEST_ALBUMS)
+    global.fetch = vi.fn().mockImplementation((url, options) => {
+      if (url.includes('/library/sync') && !url.includes('/sync-complete') && options?.method === 'POST') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(SYNC_DONE) })
+      }
+      if (url.includes('/library/sync-complete') && options?.method === 'POST') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) })
+      }
+      if (url.includes('/library/albums') && !url.includes('/tracks')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ albums: TEST_ALBUMS, total: 1 }) })
+      }
+      if (url.includes('/collections')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(COLLECTIONS_OK) })
+      }
+      if (url.includes('/home')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(HOME_OK) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+
+    render(<App />)
+
+    // Navigate to Library
+    await userEvent.click(await screen.findByRole('button', { name: /^library( syncing)?$/i }))
+    expect(await screen.findByText('Selectable Album')).toBeInTheDocument()
+
+    // Select an album via the toggle button
+    const selectBtn = screen.getByRole('button', { name: /add to collection/i })
+    await userEvent.click(selectBtn)
+
+    // BulkAddBar should now be visible
+    expect(screen.getByRole('button', { name: /clear selection/i })).toBeInTheDocument()
+
+    // Navigate away to Home
+    await userEvent.click(screen.getByRole('button', { name: /home/i }))
+
+    // BulkAddBar should be gone (selection cleared)
+    expect(screen.queryByRole('button', { name: /clear selection/i })).not.toBeInTheDocument()
+
+    clearLocalStorageCache()
+  })
+})
+
 describe('App — create collection from nav bar', () => {
   it('shows a create collection button in nav when on collections view', async () => {
     seedLocalStorageCache()


### PR DESCRIPTION
## Summary
- BulkAddBar (album selection bar) was persisting when navigating away from the library view because `selectedAlbumIds` state was never cleared on view change
- Added a `useEffect` that clears `selectedAlbumIds` and `pickerAlbumIds` when `view` changes away from `'library'`
- Added integration test verifying the bar disappears on navigation

## Test plan
- [x] New test: selecting albums in library, navigating to home, verifying BulkAddBar disappears
- [x] All 519 existing tests pass

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)