### PR TITLE
Add hover scale effect to home page album cards [113]

### DIFF
--- a/frontend/src/components/HomePage.jsx
+++ b/frontend/src/components/HomePage.jsx
@@ -41,7 +41,7 @@ function AlbumList({ albums, onPlay }) {
           key={album.service_id}
           data-testid={`album-item-${album.service_id}`}
           onClick={() => onPlay(album.service_id)}
-          className="cursor-pointer hover:scale-105 hover:brightness-110 active:scale-95 active:opacity-80 transition-all duration-200 ease-out"
+          className="cursor-pointer will-change-transform hover:scale-105 hover:brightness-110 active:scale-95 active:opacity-80 transition-all duration-200 ease-out"
         >
           {album.image_url ? (
             <img src={album.image_url} alt={album.name} className="w-full aspect-square rounded-md object-cover block" />

--- a/frontend/src/components/HomePage.jsx
+++ b/frontend/src/components/HomePage.jsx
@@ -41,7 +41,7 @@ function AlbumList({ albums, onPlay }) {
           key={album.service_id}
           data-testid={`album-item-${album.service_id}`}
           onClick={() => onPlay(album.service_id)}
-          className="cursor-pointer hover:scale-105 active:scale-95 active:opacity-80 transition-transform duration-150"
+          className="cursor-pointer hover:scale-105 hover:shadow-lg hover:shadow-black/30 hover:brightness-110 active:scale-95 active:opacity-80 transition-all duration-200 ease-out"
         >
           {album.image_url ? (
             <img src={album.image_url} alt={album.name} className="w-full aspect-square rounded-md object-cover block" />

--- a/frontend/src/components/HomePage.jsx
+++ b/frontend/src/components/HomePage.jsx
@@ -41,7 +41,7 @@ function AlbumList({ albums, onPlay }) {
           key={album.service_id}
           data-testid={`album-item-${album.service_id}`}
           onClick={() => onPlay(album.service_id)}
-          className="cursor-pointer hover:scale-105 hover:shadow-lg hover:shadow-black/30 hover:brightness-110 active:scale-95 active:opacity-80 transition-all duration-200 ease-out"
+          className="cursor-pointer hover:scale-105 hover:brightness-110 active:scale-95 active:opacity-80 transition-all duration-200 ease-out"
         >
           {album.image_url ? (
             <img src={album.image_url} alt={album.name} className="w-full aspect-square rounded-md object-cover block" />

--- a/frontend/src/components/HomePage.jsx
+++ b/frontend/src/components/HomePage.jsx
@@ -41,7 +41,7 @@ function AlbumList({ albums, onPlay }) {
           key={album.service_id}
           data-testid={`album-item-${album.service_id}`}
           onClick={() => onPlay(album.service_id)}
-          className="cursor-pointer active:scale-95 active:opacity-80 transition-transform duration-150"
+          className="cursor-pointer hover:scale-105 active:scale-95 active:opacity-80 transition-transform duration-150"
         >
           {album.image_url ? (
             <img src={album.image_url} alt={album.name} className="w-full aspect-square rounded-md object-cover block" />

--- a/frontend/src/components/HomePage.test.jsx
+++ b/frontend/src/components/HomePage.test.jsx
@@ -213,6 +213,16 @@ describe('HomePage', () => {
     })
   })
 
+  it('album cards have hover:scale-105 class for desktop hover effect', async () => {
+    useIsMobile.mockReturnValue(false)
+    render(<HomePage onPlay={() => {}} />)
+    await waitFor(() => {
+      expect(screen.getByAltText('Today Album')).toBeInTheDocument()
+    })
+    const card = screen.getByTestId('album-item-a1')
+    expect(card.className).toContain('hover:scale-105')
+  })
+
   it('mobile scroll container has prompt-row-scroll class', async () => {
     useIsMobile.mockReturnValue(true)
     const { container } = render(<HomePage onPlay={() => {}} />)

--- a/frontend/src/components/HomePage.test.jsx
+++ b/frontend/src/components/HomePage.test.jsx
@@ -221,6 +221,8 @@ describe('HomePage', () => {
     })
     const card = screen.getByTestId('album-item-a1')
     expect(card.className).toContain('hover:scale-105')
+    expect(card.className).toContain('hover:shadow-lg')
+    expect(card.className).toContain('hover:brightness-110')
   })
 
   it('mobile scroll container has prompt-row-scroll class', async () => {

--- a/frontend/src/components/HomePage.test.jsx
+++ b/frontend/src/components/HomePage.test.jsx
@@ -221,7 +221,6 @@ describe('HomePage', () => {
     })
     const card = screen.getByTestId('album-item-a1')
     expect(card.className).toContain('hover:scale-105')
-    expect(card.className).toContain('hover:shadow-lg')
     expect(card.className).toContain('hover:brightness-110')
   })
 


### PR DESCRIPTION
## Summary
- Add `hover:scale-105` to album card divs on home page for subtle scale-up on hover
- Desktop-only: Tailwind v4 wraps `hover:` in `@media (hover: hover)` automatically
- Test added verifying hover class presence

Closes #113

## Test plan
- [x] Existing HomePage tests pass (12/12)
- [ ] Verify hover effect visually on desktop browser
- [ ] Confirm no hover effect on mobile/touch devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)