### PR TITLE
Sync volume slider with Spotify playback volume [127]

### DIFF
--- a/backend/routers/playback.py
+++ b/backend/routers/playback.py
@@ -60,6 +60,7 @@ def get_playback_state(sp: spotipy.Spotify = Depends(get_user_spotify)):
             "id": device.get("id"),
             "name": device["name"],
             "type": device["type"],
+            "volume_percent": device.get("volume_percent"),
         }
         if device
         else None,

--- a/backend/tests/test_playback.py
+++ b/backend/tests/test_playback.py
@@ -22,7 +22,12 @@ PLAYBACK_STATE = {
         },
         "artists": [{"name": "Artist A"}, {"name": "Artist B"}],
     },
-    "device": {"id": "device-id-abc", "name": "My Mac", "type": "Computer", "volume_percent": 72},
+    "device": {
+        "id": "device-id-abc",
+        "name": "My Mac",
+        "type": "Computer",
+        "volume_percent": 72,
+    },
 }
 
 

--- a/backend/tests/test_playback.py
+++ b/backend/tests/test_playback.py
@@ -22,7 +22,7 @@ PLAYBACK_STATE = {
         },
         "artists": [{"name": "Artist A"}, {"name": "Artist B"}],
     },
-    "device": {"id": "device-id-abc", "name": "My Mac", "type": "Computer"},
+    "device": {"id": "device-id-abc", "name": "My Mac", "type": "Computer", "volume_percent": 72},
 }
 
 
@@ -62,6 +62,7 @@ def test_get_playback_state_returns_simplified_shape():
     assert data["device"]["id"] == "device-id-abc"
     assert data["device"]["name"] == "My Mac"
     assert data["device"]["type"] == "Computer"
+    assert data["device"]["volume_percent"] == 72
 
     clear_overrides()
 

--- a/frontend/src/components/PlaybackBar.jsx
+++ b/frontend/src/components/PlaybackBar.jsx
@@ -150,7 +150,13 @@ export default function PlaybackBar({
   onOpenDevicePicker,
 }) {
   const { is_playing, track, device } = state
-  const [volume, setVolume] = useState(50)
+  const [volume, setVolume] = useState(state?.device?.volume_percent ?? 50)
+
+  useEffect(() => {
+    if (state?.device?.volume_percent != null) {
+      setVolume(state.device.volume_percent)
+    }
+  }, [state?.device?.volume_percent])
 
   const artistLine = track ? track.artists.join(', ') : null
 

--- a/frontend/src/components/PlaybackBar.test.jsx
+++ b/frontend/src/components/PlaybackBar.test.jsx
@@ -796,6 +796,59 @@ describe('PlaybackBar', () => {
 
   // --- Volume slider ---
 
+  it('initializes volume slider from state.device.volume_percent instead of hardcoded 50', () => {
+    const stateWithVolume = {
+      ...PLAYING_STATE,
+      device: { ...PLAYING_STATE.device, volume_percent: 75 },
+    }
+    render(
+      <PlaybackBar
+        state={stateWithVolume}
+        onPlay={vi.fn()}
+        onPause={vi.fn()}
+        paneOpen={false}
+        onTogglePane={vi.fn()}
+        onSetVolume={vi.fn()}
+      />
+    )
+    const slider = screen.getByRole('slider', { name: 'Volume' })
+    expect(slider).toHaveAttribute('aria-valuenow', '75')
+  })
+
+  it('syncs volume slider when state.device.volume_percent changes', () => {
+    const stateWithVolume = {
+      ...PLAYING_STATE,
+      device: { ...PLAYING_STATE.device, volume_percent: 40 },
+    }
+    const { rerender } = render(
+      <PlaybackBar
+        state={stateWithVolume}
+        onPlay={vi.fn()}
+        onPause={vi.fn()}
+        paneOpen={false}
+        onTogglePane={vi.fn()}
+        onSetVolume={vi.fn()}
+      />
+    )
+    expect(screen.getByRole('slider', { name: 'Volume' })).toHaveAttribute('aria-valuenow', '40')
+
+    const updatedState = {
+      ...PLAYING_STATE,
+      device: { ...PLAYING_STATE.device, volume_percent: 80 },
+    }
+    rerender(
+      <PlaybackBar
+        state={updatedState}
+        onPlay={vi.fn()}
+        onPause={vi.fn()}
+        paneOpen={false}
+        onTogglePane={vi.fn()}
+        onSetVolume={vi.fn()}
+      />
+    )
+    expect(screen.getByRole('slider', { name: 'Volume' })).toHaveAttribute('aria-valuenow', '80')
+  })
+
   it('renders a volume slider in the right zone', () => {
     render(
       <PlaybackBar

--- a/frontend/src/usePlayback.test.js
+++ b/frontend/src/usePlayback.test.js
@@ -10,7 +10,7 @@ const PLAYBACK_STATE = {
     progress_ms: 45000,
     duration_ms: 240000,
   },
-  device: { id: 'device-id-abc', name: 'My Mac', type: 'Computer' },
+  device: { id: 'device-id-abc', name: 'My Mac', type: 'Computer', volume_percent: 72 },
 }
 
 const IDLE_STATE = { is_playing: false, track: null, device: null }
@@ -516,7 +516,7 @@ describe('transferPlayback', () => {
     const newState = {
       is_playing: true,
       track: { name: 'Song', album: 'Album', artists: ['Artist'], progress_ms: 0, duration_ms: 200000 },
-      device: { id: 'device-id-abc', name: 'My Mac', type: 'Computer' },
+      device: { id: 'device-id-abc', name: 'My Mac', type: 'Computer', volume_percent: 72 },
     }
 
     fetchMock = vi.fn().mockImplementation((url, opts) => {


### PR DESCRIPTION
## Summary
- Backend `/playback/state` now includes `device.volume_percent` from Spotify API
- Frontend volume slider initializes from actual device volume instead of hardcoded 50%
- `useEffect` keeps slider synced when polling updates arrive
- Falls back to 50% when no device is active

Closes #127

## Test plan
- [x] Backend test: `/state` response includes `volume_percent` (217 passed)
- [x] Frontend test: slider initializes from `state.device.volume_percent` (520 passed)
- [x] Frontend test: slider syncs when volume changes via polling
- [ ] Manual: open app with Spotify at non-50% volume, confirm slider matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)