### PR TITLE
Add worktree permissions and fix branch-protection rules

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,36 @@
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Edit(*)",
+      "Write(*)",
+      "Skill(*)",
+      "Bash(gh:*)",
+      "Bash(npm:*)",
+      "Bash(npx:*)",
+      "Bash(node:*)",
+      "Bash(python:*)",
+      "Bash(python3:*)",
+      "Bash(pip:*)",
+      "Bash(pytest:*)",
+      "Bash(make:*)",
+      "Bash(wt:*)",
+      "Bash(vercel:*)",
+      "Bash(cd:*)",
+      "Bash(ls:*)",
+      "Bash(rm:*)",
+      "Bash(mv:*)",
+      "Bash(cp:*)",
+      "Bash(mkdir:*)",
+      "Bash(curl:*)",
+      "Bash(source:*)",
+      "Bash(supabase:*)",
+      "Bash(./*)",
+      "Bash(*/.venv/bin/*)",
+      "Bash(cd * && *)",
+      "Bash(source * && *)",
+      "mcp__supabase__*"
+    ],
+    "additionalDirectories": []
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,7 @@ frontend/test-results/
 .vercel
 .env.tmp.*
 
-# AI tooling — track hookify rules, ignore settings (sandbox-blocked) and ephemeral
-.claude/settings.json
+# AI tooling — track hookify rules, ignore local settings and ephemeral
 .claude/settings.local.json
 .claude/worktrees/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,8 @@ Avoid patterns that trigger sandbox approval prompts:
 - **Never commit directly to `main`** — `main` is branch-protected. All changes go through a PR, no matter how small.
 - Commit message format: concise imperative summary + bullet points for details + `Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>`
 - **Local preview before PR**: after tests pass, run `make dev-bg` (pass `MAIN_REPO=<path-to-main-repo>` if in a worktree) to start dev servers in the background, then tell the user to open `http://localhost:5173` and review. Do not push or open a PR until the user confirms the local preview looks good. Run `make stop` to clean up after. If ports 5173/8000 are already in use (another agent's preview is running), do NOT kill them — just tell the user another preview is active and wait for them to finish that review first.
-- Mark PR ready for review when work is complete; main thread merges to `main`
+- **Never auto-merge** — auto-merge is disabled on this repo. After CI passes, the user merges manually. Never use `--auto` or `--admin` flags with `gh pr merge`.
+- Mark PR ready for review when work is complete; user merges to `main`
 - Compatible with worktrees — agents can work in isolated worktrees on their branch
 - Never commit `.env` files or secrets
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ Avoid patterns that trigger sandbox approval prompts:
 
 ## Git workflow
 
+- **`main` is production** — merging to main triggers a Vercel production deploy to live users. Treat every merge as a production release. Never push, force-push, or merge to main without passing CI and user approval.
 - **Issue-first**: every code change starts from a GitHub issue
 - **Branch from issue**: branch name is `<issue-number>-<short-title>`, e.g. `18-library-sync-wipes-cache`. No `feat/` prefix.
 - **Draft PR immediately**: push branch and open a draft PR linking the issue before writing code. This gives visibility and a place for discussion.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,8 +83,9 @@ Avoid patterns that trigger sandbox approval prompts:
 - **Draft PR immediately**: push branch and open a draft PR linking the issue before writing code. This gives visibility and a place for discussion.
 - **Auto-commit** when all tests pass — no need to ask permission
 - **One commit per agent task** — each background agent should commit its own work when done
-- For small in-thread fixes (< 5 lines, single file): commit directly to `main`
+- **Never commit directly to `main`** — `main` is branch-protected. All changes go through a PR, no matter how small.
 - Commit message format: concise imperative summary + bullet points for details + `Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>`
+- **Local preview before PR**: after tests pass, run `make dev-bg` (pass `MAIN_REPO=<path-to-main-repo>` if in a worktree) to start dev servers in the background, then tell the user to open `http://localhost:5173` and review. Do not push or open a PR until the user confirms the local preview looks good. Run `make stop` to clean up after. If ports 5173/8000 are already in use (another agent's preview is running), do NOT kill them — just tell the user another preview is active and wait for them to finish that review first.
 - Mark PR ready for review when work is complete; main thread merges to `main`
 - Compatible with worktrees — agents can work in isolated worktrees on their branch
 - Never commit `.env` files or secrets

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,32 @@ stop:
 	@lsof -ti :5173 | xargs kill -9 2>/dev/null || true
 	@echo "Stopped."
 
-dev: stop
+dev: stop _ensure-env
 	@source backend/.venv/bin/activate && cd backend && uvicorn main:app --reload > /tmp/bsi-backend.log 2>&1 & echo $$! > /tmp/bsi-backend.pid
 	@cd frontend && npm run dev > /tmp/bsi-frontend.log 2>&1 & echo $$! > /tmp/bsi-frontend.pid
 	@echo "Backend:  http://127.0.0.1:8000"
 	@echo "Frontend: http://localhost:5173"
 	@trap 'kill $$(cat /tmp/bsi-backend.pid) $$(cat /tmp/bsi-frontend.pid) 2>/dev/null' EXIT INT; tail -f /tmp/bsi-backend.log /tmp/bsi-frontend.log
+
+# Non-blocking variant for agents — starts servers and returns immediately
+dev-bg: stop _ensure-env
+	@source backend/.venv/bin/activate && cd backend && uvicorn main:app --reload > /tmp/bsi-backend.log 2>&1 & echo $$! > /tmp/bsi-backend.pid
+	@cd frontend && npm run dev > /tmp/bsi-frontend.log 2>&1 & echo $$! > /tmp/bsi-frontend.pid
+	@sleep 2
+	@echo "Backend:  http://127.0.0.1:8000"
+	@echo "Frontend: http://localhost:5173"
+	@echo "Logs: /tmp/bsi-backend.log, /tmp/bsi-frontend.log"
+
+# Ensure .env and .venv exist (symlink from main repo when running in a worktree)
+_ensure-env:
+	@if [ ! -f backend/.env ] && [ -f "$(MAIN_REPO)/backend/.env" ]; then \
+		ln -s "$(MAIN_REPO)/backend/.env" backend/.env; \
+		echo "Symlinked backend/.env from main repo"; \
+	fi
+	@if [ ! -d backend/.venv ] && [ -d "$(MAIN_REPO)/backend/.venv" ]; then \
+		ln -s "$(MAIN_REPO)/backend/.venv" backend/.venv; \
+		echo "Symlinked backend/.venv from main repo"; \
+	fi
 
 backend:
 	@source backend/.venv/bin/activate && cd backend && uvicorn main:app --reload


### PR DESCRIPTION
## Summary
- Add shared `.claude/settings.json` so worktree agents inherit same tool permissions
- Un-ignore `settings.json` in `.gitignore` (local-only `settings.local.json` stays ignored)
- Replace "commit directly to main" rule with explicit branch-protection note in CLAUDE.md
- Add `dev-bg` and `_ensure-env` Makefile targets for worktree dev workflow

## Test plan
- [ ] Verify worktree agent gets permissions without prompting
- [ ] Confirm `make dev-bg` starts servers in background

🤖 Generated with [Claude Code](https://claude.com/claude-code)