### PR TITLE
Deduplicate albums after library sync [136]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ bummer/
 - Backend tests: `backend/.venv/bin/python -m pytest` from `backend/` (use `-C` flag or absolute path, never `cd`)
 - Frontend tests: `npx vitest --run` from `frontend/` (use `--prefix` or absolute path, never `cd`)
 - Never write implementation code without a failing test first
+- **Linting (CI-enforced)**: before every commit that touches backend Python files, run both `backend/.venv/bin/ruff check backend/` and `backend/.venv/bin/ruff format --check backend/`. Fix any issues with `ruff check --fix` and `ruff format`. CI runs both checks and will fail the PR if either reports errors.
 
 ## Database migrations
 

--- a/backend/dedup.py
+++ b/backend/dedup.py
@@ -1,5 +1,10 @@
 from collections import defaultdict
 
+try:
+    from supabase import Client
+except ImportError:
+    Client = object  # type: ignore[assignment,misc]
+
 
 def _normalize_for_matching(s: str) -> str:
     """Lowercase and strip whitespace for dedup matching."""
@@ -49,3 +54,77 @@ def find_duplicates(albums: list[dict]) -> list[tuple[dict, list[dict]]]:
             winner, losers = _pick_winner(group)
             results.append((winner, losers))
     return results
+
+
+def _migrate_metadata(db: Client, user_id: str, old_id: str, new_id: str) -> None:
+    """Migrate tier and collection memberships from old to new service_id."""
+    # Migrate tier (only if new doesn't have one)
+    new_tier = (
+        db.table("album_metadata")
+        .select("tier")
+        .eq("service_id", new_id)
+        .eq("user_id", user_id)
+        .execute()
+    )
+    old_tier = (
+        db.table("album_metadata")
+        .select("tier")
+        .eq("service_id", old_id)
+        .eq("user_id", user_id)
+        .execute()
+    )
+    if old_tier.data and old_tier.data[0].get("tier"):
+        if not new_tier.data or not new_tier.data[0].get("tier"):
+            db.table("album_metadata").upsert(
+                {"service_id": new_id, "tier": old_tier.data[0]["tier"], "user_id": user_id}
+            ).execute()
+        db.table("album_metadata").delete().eq("service_id", old_id).eq("user_id", user_id).execute()
+
+    # Migrate collection memberships
+    old_memberships = (
+        db.table("collection_albums")
+        .select("collection_id, position")
+        .eq("service_id", old_id)
+        .eq("user_id", user_id)
+        .execute()
+    )
+    for membership in old_memberships.data:
+        existing = (
+            db.table("collection_albums")
+            .select("service_id")
+            .eq("collection_id", membership["collection_id"])
+            .eq("service_id", new_id)
+            .execute()
+        )
+        if not existing.data:
+            db.table("collection_albums").upsert(
+                {
+                    "collection_id": membership["collection_id"],
+                    "service_id": new_id,
+                    "position": membership["position"],
+                    "user_id": user_id,
+                }
+            ).execute()
+    db.table("collection_albums").delete().eq("service_id", old_id).eq("user_id", user_id).execute()
+
+
+def apply_dedup(db: Client, user_id: str, albums: list[dict]) -> list[dict]:
+    """Find cross-ID duplicates, migrate metadata, record dedup, return filtered list."""
+    dupes = find_duplicates(albums)
+    if not dupes:
+        return albums
+
+    loser_ids = set()
+    for winner, losers in dupes:
+        for loser in losers:
+            _migrate_metadata(db, user_id, loser["service_id"], winner["service_id"])
+            db.table("deduped_albums").insert(
+                {
+                    "old_service_id": loser["service_id"],
+                    "new_service_id": winner["service_id"],
+                    "user_id": user_id,
+                }
+            ).execute()
+            loser_ids.add(loser["service_id"])
+
+    return [a for a in albums if a["service_id"] not in loser_ids]

--- a/backend/dedup.py
+++ b/backend/dedup.py
@@ -76,9 +76,15 @@ def _migrate_metadata(db: Client, user_id: str, old_id: str, new_id: str) -> Non
     if old_tier.data and old_tier.data[0].get("tier"):
         if not new_tier.data or not new_tier.data[0].get("tier"):
             db.table("album_metadata").upsert(
-                {"service_id": new_id, "tier": old_tier.data[0]["tier"], "user_id": user_id}
+                {
+                    "service_id": new_id,
+                    "tier": old_tier.data[0]["tier"],
+                    "user_id": user_id,
+                }
             ).execute()
-        db.table("album_metadata").delete().eq("service_id", old_id).eq("user_id", user_id).execute()
+        db.table("album_metadata").delete().eq("service_id", old_id).eq(
+            "user_id", user_id
+        ).execute()
 
     # Migrate collection memberships
     old_memberships = (
@@ -105,7 +111,9 @@ def _migrate_metadata(db: Client, user_id: str, old_id: str, new_id: str) -> Non
                     "user_id": user_id,
                 }
             ).execute()
-    db.table("collection_albums").delete().eq("service_id", old_id).eq("user_id", user_id).execute()
+    db.table("collection_albums").delete().eq("service_id", old_id).eq(
+        "user_id", user_id
+    ).execute()
 
 
 def apply_dedup(db: Client, user_id: str, albums: list[dict]) -> list[dict]:

--- a/backend/dedup.py
+++ b/backend/dedup.py
@@ -1,0 +1,51 @@
+from collections import defaultdict
+
+
+def _normalize_for_matching(s: str) -> str:
+    """Lowercase and strip whitespace for dedup matching."""
+    return s.strip().lower()
+
+
+def _dedup_key(album: dict) -> tuple[str, str, int]:
+    """Return (normalized_first_artist, normalized_name, total_tracks) for matching."""
+    artists = album.get("artists", [])
+    first_artist = ""
+    if artists:
+        a = artists[0]
+        first_artist = a["name"] if isinstance(a, dict) else a
+    return (
+        _normalize_for_matching(first_artist),
+        _normalize_for_matching(album.get("name", "")),
+        album.get("total_tracks", 0),
+    )
+
+
+def _pick_winner(albums: list[dict]) -> tuple[dict, list[dict]]:
+    """Pick the newest album as winner. Returns (winner, losers).
+
+    Sorts by release_date descending, then added_at descending as tiebreaker.
+    """
+
+    def sort_key(album):
+        return (album.get("release_date") or "", album.get("added_at") or "")
+
+    ranked = sorted(albums, key=sort_key, reverse=True)
+    return ranked[0], ranked[1:]
+
+
+def find_duplicates(albums: list[dict]) -> list[tuple[dict, list[dict]]]:
+    """Group albums by dedup key, return (winner, losers) for each duplicate group.
+
+    Only groups with 2+ albums are returned. Singletons are ignored.
+    """
+    groups: dict[tuple, list[dict]] = defaultdict(list)
+    for album in albums:
+        key = _dedup_key(album)
+        groups[key].append(album)
+
+    results = []
+    for group in groups.values():
+        if len(group) >= 2:
+            winner, losers = _pick_winner(group)
+            results.append((winner, losers))
+    return results

--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -147,7 +147,12 @@ def sync_complete(
     user_id = user["user_id"]
 
     # Filter out previously deduped albums
-    suppressed = db.table("deduped_albums").select("old_service_id").eq("user_id", user_id).execute()
+    suppressed = (
+        db.table("deduped_albums")
+        .select("old_service_id")
+        .eq("user_id", user_id)
+        .execute()
+    )
     suppressed_ids = {r["old_service_id"] for r in suppressed.data}
     albums = [a for a in body.albums if a["service_id"] not in suppressed_ids]
 

--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -146,11 +146,16 @@ def sync_complete(
 ):
     user_id = user["user_id"]
 
+    # Filter out previously deduped albums
+    suppressed = db.table("deduped_albums").select("old_service_id").eq("user_id", user_id).execute()
+    suppressed_ids = {r["old_service_id"] for r in suppressed.data}
+    albums = [a for a in body.albums if a["service_id"] not in suppressed_ids]
+
     # Read current cache to compute diff
     existing = _get_supabase_cache(db, user_id=user_id)
     if existing and existing.get("albums"):
         old_ids = {a["service_id"] for a in existing["albums"]}
-        new_ids = {a["service_id"] for a in body.albums}
+        new_ids = {a["service_id"] for a in albums}
         added = list(new_ids - old_ids)
         removed = list(old_ids - new_ids)
         if added or removed:
@@ -162,8 +167,17 @@ def sync_complete(
                 }
             ).execute()
 
-    _save_supabase_cache(db, body.albums, len(body.albums), user_id)
-    return {"total": len(body.albums)}
+    _save_supabase_cache(db, albums, len(albums), user_id)
+
+    # Run cross-ID dedup on the cached albums
+    from dedup import apply_dedup
+
+    deduped_albums = apply_dedup(db, user_id, albums)
+    if len(deduped_albums) < len(albums):
+        # Re-save cache with losers removed
+        _save_supabase_cache(db, deduped_albums, len(deduped_albums), user_id)
+
+    return {"total": len(deduped_albums)}
 
 
 def _format_duration(ms: int) -> str:

--- a/backend/tests/test_dedup.py
+++ b/backend/tests/test_dedup.py
@@ -1,4 +1,26 @@
-from dedup import _dedup_key, _normalize_for_matching, _pick_winner, find_duplicates
+from unittest.mock import MagicMock
+
+from dedup import _dedup_key, _normalize_for_matching, _pick_winner, apply_dedup, find_duplicates
+
+
+def _mock_db():
+    """Mock DB that routes table calls and tracks interactions."""
+    db = MagicMock()
+    tables = {}
+
+    def table_router(name):
+        if name not in tables:
+            tables[name] = MagicMock()
+            tables[name].select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+            tables[name].select.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+            tables[name].upsert.return_value.execute.return_value = MagicMock(data=[])
+            tables[name].insert.return_value.execute.return_value = MagicMock(data=[])
+            tables[name].delete.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+        return tables[name]
+
+    db.table.side_effect = table_router
+    db._tables = tables
+    return db
 
 
 def test_normalize_strips_whitespace_and_lowercases():
@@ -101,3 +123,84 @@ def test_find_duplicates_ignores_different_track_counts():
     deluxe = {"service_id": "d1", "name": "Rumours", "artists": ["Fleetwood Mac"], "total_tracks": 22, "release_date": "2013", "added_at": "2020-06-01T00:00:00Z"}
 
     assert find_duplicates([standard, deluxe]) == []
+
+
+def test_apply_dedup_no_duplicates_returns_albums_unchanged():
+    db = _mock_db()
+    albums = [
+        {"service_id": "a", "name": "A", "artists": [{"name": "X", "id": "x"}], "total_tracks": 10, "release_date": "2020", "added_at": "2021-01-01T00:00:00Z"},
+    ]
+    result = apply_dedup(db, "user1", albums)
+    assert result == albums
+    db.table.assert_not_called()
+
+
+def test_apply_dedup_removes_loser_and_records():
+    db = _mock_db()
+    albums = [
+        {"service_id": "old1", "name": "Blonde", "artists": [{"name": "Frank Ocean", "id": "fo"}], "total_tracks": 17, "release_date": "2016-08-20", "added_at": "2017-01-01T00:00:00Z"},
+        {"service_id": "new1", "name": "Blonde", "artists": [{"name": "Frank Ocean", "id": "fo2"}], "total_tracks": 17, "release_date": "2016-08-20", "added_at": "2023-06-01T00:00:00Z"},
+    ]
+
+    result = apply_dedup(db, "user1", albums)
+
+    assert len(result) == 1
+    assert result[0]["service_id"] == "new1"
+
+    # Dedup record inserted
+    deduped_table = db._tables["deduped_albums"]
+    deduped_table.insert.assert_called_once()
+    insert_arg = deduped_table.insert.call_args[0][0]
+    assert insert_arg["old_service_id"] == "old1"
+    assert insert_arg["new_service_id"] == "new1"
+    assert insert_arg["user_id"] == "user1"
+
+
+def test_apply_dedup_migrates_tier():
+    db = _mock_db()
+    metadata_table = db._tables.setdefault("album_metadata", MagicMock())
+
+    tier_responses = {
+        "new1": MagicMock(data=[]),
+        "old1": MagicMock(data=[{"service_id": "old1", "tier": "S", "user_id": "user1"}]),
+    }
+
+    def select_side_effect(*args, **kwargs):
+        eq_mock = MagicMock()
+        def eq_service(field, value):
+            eq2 = MagicMock()
+            def eq_user(field2, value2):
+                execute_mock = MagicMock()
+                execute_mock.execute.return_value = tier_responses.get(value, MagicMock(data=[]))
+                return execute_mock
+            eq2.eq.side_effect = eq_user
+            return eq2
+        eq_mock.eq.side_effect = eq_service
+        return eq_mock
+
+    metadata_table.select.side_effect = select_side_effect
+
+    def table_router(name):
+        if name == "album_metadata":
+            return metadata_table
+        if name not in db._tables:
+            db._tables[name] = MagicMock()
+            db._tables[name].select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+            db._tables[name].insert.return_value.execute.return_value = MagicMock(data=[])
+            db._tables[name].delete.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+        return db._tables[name]
+
+    db.table.side_effect = table_router
+
+    albums = [
+        {"service_id": "old1", "name": "Blonde", "artists": [{"name": "Frank Ocean", "id": "fo"}], "total_tracks": 17, "release_date": "2016", "added_at": "2017-01-01T00:00:00Z"},
+        {"service_id": "new1", "name": "Blonde", "artists": [{"name": "Frank Ocean", "id": "fo2"}], "total_tracks": 17, "release_date": "2016", "added_at": "2023-06-01T00:00:00Z"},
+    ]
+
+    result = apply_dedup(db, "user1", albums)
+    assert len(result) == 1
+
+    metadata_table.upsert.assert_called_once()
+    upsert_arg = metadata_table.upsert.call_args[0][0]
+    assert upsert_arg["service_id"] == "new1"
+    assert upsert_arg["tier"] == "S"

--- a/backend/tests/test_dedup.py
+++ b/backend/tests/test_dedup.py
@@ -17,11 +17,23 @@ def _mock_db():
     def table_router(name):
         if name not in tables:
             tables[name] = MagicMock()
-            tables[name].select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
-            tables[name].select.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+            tables[
+                name
+            ].select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+                data=[]
+            )
+            tables[
+                name
+            ].select.return_value.eq.return_value.execute.return_value = MagicMock(
+                data=[]
+            )
             tables[name].upsert.return_value.execute.return_value = MagicMock(data=[])
             tables[name].insert.return_value.execute.return_value = MagicMock(data=[])
-            tables[name].delete.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+            tables[
+                name
+            ].delete.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+                data=[]
+            )
         return tables[name]
 
     db.table.side_effect = table_router
@@ -71,24 +83,48 @@ def test_dedup_key_multiple_artists_uses_first():
 
 
 def test_pick_winner_prefers_later_release_date():
-    old = {"service_id": "old1", "release_date": "2020-01-01", "added_at": "2022-06-01T00:00:00Z"}
-    new = {"service_id": "new1", "release_date": "2023-01-01", "added_at": "2021-01-01T00:00:00Z"}
+    old = {
+        "service_id": "old1",
+        "release_date": "2020-01-01",
+        "added_at": "2022-06-01T00:00:00Z",
+    }
+    new = {
+        "service_id": "new1",
+        "release_date": "2023-01-01",
+        "added_at": "2021-01-01T00:00:00Z",
+    }
     winner, losers = _pick_winner([old, new])
     assert winner["service_id"] == "new1"
     assert [x["service_id"] for x in losers] == ["old1"]
 
 
 def test_pick_winner_uses_added_at_as_tiebreaker():
-    a = {"service_id": "a1", "release_date": "2020-01-01", "added_at": "2022-01-01T00:00:00Z"}
-    b = {"service_id": "b1", "release_date": "2020-01-01", "added_at": "2023-06-01T00:00:00Z"}
+    a = {
+        "service_id": "a1",
+        "release_date": "2020-01-01",
+        "added_at": "2022-01-01T00:00:00Z",
+    }
+    b = {
+        "service_id": "b1",
+        "release_date": "2020-01-01",
+        "added_at": "2023-06-01T00:00:00Z",
+    }
     winner, losers = _pick_winner([a, b])
     assert winner["service_id"] == "b1"
     assert [x["service_id"] for x in losers] == ["a1"]
 
 
 def test_pick_winner_handles_partial_release_dates():
-    old = {"service_id": "old1", "release_date": "2020", "added_at": "2021-01-01T00:00:00Z"}
-    new = {"service_id": "new1", "release_date": "2023", "added_at": "2022-01-01T00:00:00Z"}
+    old = {
+        "service_id": "old1",
+        "release_date": "2020",
+        "added_at": "2021-01-01T00:00:00Z",
+    }
+    new = {
+        "service_id": "new1",
+        "release_date": "2023",
+        "added_at": "2022-01-01T00:00:00Z",
+    }
     winner, losers = _pick_winner([old, new])
     assert winner["service_id"] == "new1"
 
@@ -104,16 +140,51 @@ def test_pick_winner_three_albums_picks_newest():
 
 def test_find_duplicates_returns_empty_for_no_dupes():
     albums = [
-        {"service_id": "a", "name": "Album A", "artists": [{"name": "X", "id": "x"}], "total_tracks": 10, "release_date": "2020", "added_at": "2021-01-01T00:00:00Z"},
-        {"service_id": "b", "name": "Album B", "artists": [{"name": "Y", "id": "y"}], "total_tracks": 8, "release_date": "2019", "added_at": "2020-01-01T00:00:00Z"},
+        {
+            "service_id": "a",
+            "name": "Album A",
+            "artists": [{"name": "X", "id": "x"}],
+            "total_tracks": 10,
+            "release_date": "2020",
+            "added_at": "2021-01-01T00:00:00Z",
+        },
+        {
+            "service_id": "b",
+            "name": "Album B",
+            "artists": [{"name": "Y", "id": "y"}],
+            "total_tracks": 8,
+            "release_date": "2019",
+            "added_at": "2020-01-01T00:00:00Z",
+        },
     ]
     assert find_duplicates(albums) == []
 
 
 def test_find_duplicates_detects_same_artist_name_tracks():
-    old = {"service_id": "old1", "name": "Blonde", "artists": [{"name": "Frank Ocean", "id": "fo"}], "total_tracks": 17, "release_date": "2016-08-20", "added_at": "2017-01-01T00:00:00Z"}
-    new = {"service_id": "new1", "name": "Blonde", "artists": [{"name": "Frank Ocean", "id": "fo2"}], "total_tracks": 17, "release_date": "2016-08-20", "added_at": "2023-06-01T00:00:00Z"}
-    unrelated = {"service_id": "u1", "name": "Channel Orange", "artists": [{"name": "Frank Ocean", "id": "fo"}], "total_tracks": 17, "release_date": "2012", "added_at": "2013-01-01T00:00:00Z"}
+    old = {
+        "service_id": "old1",
+        "name": "Blonde",
+        "artists": [{"name": "Frank Ocean", "id": "fo"}],
+        "total_tracks": 17,
+        "release_date": "2016-08-20",
+        "added_at": "2017-01-01T00:00:00Z",
+    }
+    new = {
+        "service_id": "new1",
+        "name": "Blonde",
+        "artists": [{"name": "Frank Ocean", "id": "fo2"}],
+        "total_tracks": 17,
+        "release_date": "2016-08-20",
+        "added_at": "2023-06-01T00:00:00Z",
+    }
+    unrelated = {
+        "service_id": "u1",
+        "name": "Channel Orange",
+        "artists": [{"name": "Frank Ocean", "id": "fo"}],
+        "total_tracks": 17,
+        "release_date": "2012",
+        "added_at": "2013-01-01T00:00:00Z",
+    }
 
     results = find_duplicates([old, new, unrelated])
 
@@ -125,8 +196,22 @@ def test_find_duplicates_detects_same_artist_name_tracks():
 
 def test_find_duplicates_ignores_different_track_counts():
     """Same artist+name but different track count = not a duplicate (deluxe edition)."""
-    standard = {"service_id": "s1", "name": "Rumours", "artists": ["Fleetwood Mac"], "total_tracks": 11, "release_date": "1977", "added_at": "2020-01-01T00:00:00Z"}
-    deluxe = {"service_id": "d1", "name": "Rumours", "artists": ["Fleetwood Mac"], "total_tracks": 22, "release_date": "2013", "added_at": "2020-06-01T00:00:00Z"}
+    standard = {
+        "service_id": "s1",
+        "name": "Rumours",
+        "artists": ["Fleetwood Mac"],
+        "total_tracks": 11,
+        "release_date": "1977",
+        "added_at": "2020-01-01T00:00:00Z",
+    }
+    deluxe = {
+        "service_id": "d1",
+        "name": "Rumours",
+        "artists": ["Fleetwood Mac"],
+        "total_tracks": 22,
+        "release_date": "2013",
+        "added_at": "2020-06-01T00:00:00Z",
+    }
 
     assert find_duplicates([standard, deluxe]) == []
 
@@ -134,7 +219,14 @@ def test_find_duplicates_ignores_different_track_counts():
 def test_apply_dedup_no_duplicates_returns_albums_unchanged():
     db = _mock_db()
     albums = [
-        {"service_id": "a", "name": "A", "artists": [{"name": "X", "id": "x"}], "total_tracks": 10, "release_date": "2020", "added_at": "2021-01-01T00:00:00Z"},
+        {
+            "service_id": "a",
+            "name": "A",
+            "artists": [{"name": "X", "id": "x"}],
+            "total_tracks": 10,
+            "release_date": "2020",
+            "added_at": "2021-01-01T00:00:00Z",
+        },
     ]
     result = apply_dedup(db, "user1", albums)
     assert result == albums
@@ -144,8 +236,22 @@ def test_apply_dedup_no_duplicates_returns_albums_unchanged():
 def test_apply_dedup_removes_loser_and_records():
     db = _mock_db()
     albums = [
-        {"service_id": "old1", "name": "Blonde", "artists": [{"name": "Frank Ocean", "id": "fo"}], "total_tracks": 17, "release_date": "2016-08-20", "added_at": "2017-01-01T00:00:00Z"},
-        {"service_id": "new1", "name": "Blonde", "artists": [{"name": "Frank Ocean", "id": "fo2"}], "total_tracks": 17, "release_date": "2016-08-20", "added_at": "2023-06-01T00:00:00Z"},
+        {
+            "service_id": "old1",
+            "name": "Blonde",
+            "artists": [{"name": "Frank Ocean", "id": "fo"}],
+            "total_tracks": 17,
+            "release_date": "2016-08-20",
+            "added_at": "2017-01-01T00:00:00Z",
+        },
+        {
+            "service_id": "new1",
+            "name": "Blonde",
+            "artists": [{"name": "Frank Ocean", "id": "fo2"}],
+            "total_tracks": 17,
+            "release_date": "2016-08-20",
+            "added_at": "2023-06-01T00:00:00Z",
+        },
     ]
 
     result = apply_dedup(db, "user1", albums)
@@ -168,19 +274,27 @@ def test_apply_dedup_migrates_tier():
 
     tier_responses = {
         "new1": MagicMock(data=[]),
-        "old1": MagicMock(data=[{"service_id": "old1", "tier": "S", "user_id": "user1"}]),
+        "old1": MagicMock(
+            data=[{"service_id": "old1", "tier": "S", "user_id": "user1"}]
+        ),
     }
 
     def select_side_effect(*args, **kwargs):
         eq_mock = MagicMock()
+
         def eq_service(field, value):
             eq2 = MagicMock()
+
             def eq_user(field2, value2):
                 execute_mock = MagicMock()
-                execute_mock.execute.return_value = tier_responses.get(value, MagicMock(data=[]))
+                execute_mock.execute.return_value = tier_responses.get(
+                    value, MagicMock(data=[])
+                )
                 return execute_mock
+
             eq2.eq.side_effect = eq_user
             return eq2
+
         eq_mock.eq.side_effect = eq_service
         return eq_mock
 
@@ -191,16 +305,40 @@ def test_apply_dedup_migrates_tier():
             return metadata_table
         if name not in db._tables:
             db._tables[name] = MagicMock()
-            db._tables[name].select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
-            db._tables[name].insert.return_value.execute.return_value = MagicMock(data=[])
-            db._tables[name].delete.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+            db._tables[
+                name
+            ].select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+                data=[]
+            )
+            db._tables[name].insert.return_value.execute.return_value = MagicMock(
+                data=[]
+            )
+            db._tables[
+                name
+            ].delete.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+                data=[]
+            )
         return db._tables[name]
 
     db.table.side_effect = table_router
 
     albums = [
-        {"service_id": "old1", "name": "Blonde", "artists": [{"name": "Frank Ocean", "id": "fo"}], "total_tracks": 17, "release_date": "2016", "added_at": "2017-01-01T00:00:00Z"},
-        {"service_id": "new1", "name": "Blonde", "artists": [{"name": "Frank Ocean", "id": "fo2"}], "total_tracks": 17, "release_date": "2016", "added_at": "2023-06-01T00:00:00Z"},
+        {
+            "service_id": "old1",
+            "name": "Blonde",
+            "artists": [{"name": "Frank Ocean", "id": "fo"}],
+            "total_tracks": 17,
+            "release_date": "2016",
+            "added_at": "2017-01-01T00:00:00Z",
+        },
+        {
+            "service_id": "new1",
+            "name": "Blonde",
+            "artists": [{"name": "Frank Ocean", "id": "fo2"}],
+            "total_tracks": 17,
+            "release_date": "2016",
+            "added_at": "2023-06-01T00:00:00Z",
+        },
     ]
 
     result = apply_dedup(db, "user1", albums)
@@ -219,10 +357,14 @@ def test_apply_dedup_full_flow_with_collections():
 
     def make_table(name):
         t = MagicMock()
-        t.select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+        t.select.return_value.eq.return_value.eq.return_value.execute.return_value = (
+            MagicMock(data=[])
+        )
         t.insert.return_value.execute.return_value = MagicMock(data=[])
         t.upsert.return_value.execute.return_value = MagicMock(data=[])
-        t.delete.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+        t.delete.return_value.eq.return_value.eq.return_value.execute.return_value = (
+            MagicMock(data=[])
+        )
         return t
 
     def table_router(name):
@@ -235,16 +377,21 @@ def test_apply_dedup_full_flow_with_collections():
     # Old album has tier B and is in collection "coll1"
     am = make_table("album_metadata")
     new_tier_resp = MagicMock(data=[])
-    old_tier_resp = MagicMock(data=[{"service_id": "old1", "tier": "B", "user_id": "u1"}])
+    old_tier_resp = MagicMock(
+        data=[{"service_id": "old1", "tier": "B", "user_id": "u1"}]
+    )
     am.select.return_value.eq.side_effect = lambda field, val: (
-        MagicMock(eq=lambda f2, v2: old_tier_resp) if val == "old1"
+        MagicMock(eq=lambda f2, v2: old_tier_resp)
+        if val == "old1"
         else MagicMock(eq=lambda f2, v2: new_tier_resp)
     )
     tables["album_metadata"] = am
 
     ca = make_table("collection_albums")
+
     def ca_select_side(*args, **kwargs):
         mock = MagicMock()
+
         def eq1(field, val):
             mock2 = MagicMock()
             if field == "service_id" and val == "old1":
@@ -256,17 +403,40 @@ def test_apply_dedup_full_flow_with_collections():
             else:
                 mock2.eq.return_value.execute.return_value = MagicMock(data=[])
             return mock2
+
         mock.eq.side_effect = eq1
         return mock
+
     ca.select.side_effect = ca_select_side
     tables["collection_albums"] = ca
 
     db.table.side_effect = table_router
 
     albums = [
-        {"service_id": "old1", "name": "Ctrl", "artists": [{"name": "SZA", "id": "s1"}], "total_tracks": 14, "release_date": "2017-06-09", "added_at": "2017-07-01T00:00:00Z"},
-        {"service_id": "new1", "name": "Ctrl", "artists": [{"name": "SZA", "id": "s2"}], "total_tracks": 14, "release_date": "2017-06-09", "added_at": "2024-01-15T00:00:00Z"},
-        {"service_id": "other", "name": "SOS", "artists": [{"name": "SZA", "id": "s1"}], "total_tracks": 23, "release_date": "2022", "added_at": "2023-01-01T00:00:00Z"},
+        {
+            "service_id": "old1",
+            "name": "Ctrl",
+            "artists": [{"name": "SZA", "id": "s1"}],
+            "total_tracks": 14,
+            "release_date": "2017-06-09",
+            "added_at": "2017-07-01T00:00:00Z",
+        },
+        {
+            "service_id": "new1",
+            "name": "Ctrl",
+            "artists": [{"name": "SZA", "id": "s2"}],
+            "total_tracks": 14,
+            "release_date": "2017-06-09",
+            "added_at": "2024-01-15T00:00:00Z",
+        },
+        {
+            "service_id": "other",
+            "name": "SOS",
+            "artists": [{"name": "SZA", "id": "s1"}],
+            "total_tracks": 23,
+            "release_date": "2022",
+            "added_at": "2023-01-01T00:00:00Z",
+        },
     ]
 
     result = apply_dedup(db, "u1", albums)

--- a/backend/tests/test_dedup.py
+++ b/backend/tests/test_dedup.py
@@ -1,0 +1,103 @@
+from dedup import _dedup_key, _normalize_for_matching, _pick_winner, find_duplicates
+
+
+def test_normalize_strips_whitespace_and_lowercases():
+    assert _normalize_for_matching("  Led Zeppelin  ") == "led zeppelin"
+
+
+def test_normalize_handles_empty_string():
+    assert _normalize_for_matching("") == ""
+
+
+def test_dedup_key_uses_first_artist_name_album_name_track_count():
+    album = {
+        "service_id": "abc",
+        "name": "Abbey Road",
+        "artists": [{"name": "The Beatles", "id": "art1"}],
+        "total_tracks": 17,
+    }
+    assert _dedup_key(album) == ("the beatles", "abbey road", 17)
+
+
+def test_dedup_key_with_string_artists():
+    album = {
+        "service_id": "abc",
+        "name": "Abbey Road",
+        "artists": ["The Beatles"],
+        "total_tracks": 17,
+    }
+    assert _dedup_key(album) == ("the beatles", "abbey road", 17)
+
+
+def test_dedup_key_multiple_artists_uses_first():
+    album = {
+        "service_id": "abc",
+        "name": "Watch the Throne",
+        "artists": [
+            {"name": "JAY-Z", "id": "a1"},
+            {"name": "Kanye West", "id": "a2"},
+        ],
+        "total_tracks": 12,
+    }
+    assert _dedup_key(album) == ("jay-z", "watch the throne", 12)
+
+
+def test_pick_winner_prefers_later_release_date():
+    old = {"service_id": "old1", "release_date": "2020-01-01", "added_at": "2022-06-01T00:00:00Z"}
+    new = {"service_id": "new1", "release_date": "2023-01-01", "added_at": "2021-01-01T00:00:00Z"}
+    winner, losers = _pick_winner([old, new])
+    assert winner["service_id"] == "new1"
+    assert [l["service_id"] for l in losers] == ["old1"]
+
+
+def test_pick_winner_uses_added_at_as_tiebreaker():
+    a = {"service_id": "a1", "release_date": "2020-01-01", "added_at": "2022-01-01T00:00:00Z"}
+    b = {"service_id": "b1", "release_date": "2020-01-01", "added_at": "2023-06-01T00:00:00Z"}
+    winner, losers = _pick_winner([a, b])
+    assert winner["service_id"] == "b1"
+    assert [l["service_id"] for l in losers] == ["a1"]
+
+
+def test_pick_winner_handles_partial_release_dates():
+    old = {"service_id": "old1", "release_date": "2020", "added_at": "2021-01-01T00:00:00Z"}
+    new = {"service_id": "new1", "release_date": "2023", "added_at": "2022-01-01T00:00:00Z"}
+    winner, losers = _pick_winner([old, new])
+    assert winner["service_id"] == "new1"
+
+
+def test_pick_winner_three_albums_picks_newest():
+    a = {"service_id": "a", "release_date": "2018", "added_at": "2019-01-01T00:00:00Z"}
+    b = {"service_id": "b", "release_date": "2023", "added_at": "2023-06-01T00:00:00Z"}
+    c = {"service_id": "c", "release_date": "2020", "added_at": "2021-01-01T00:00:00Z"}
+    winner, losers = _pick_winner([a, b, c])
+    assert winner["service_id"] == "b"
+    assert len(losers) == 2
+
+
+def test_find_duplicates_returns_empty_for_no_dupes():
+    albums = [
+        {"service_id": "a", "name": "Album A", "artists": [{"name": "X", "id": "x"}], "total_tracks": 10, "release_date": "2020", "added_at": "2021-01-01T00:00:00Z"},
+        {"service_id": "b", "name": "Album B", "artists": [{"name": "Y", "id": "y"}], "total_tracks": 8, "release_date": "2019", "added_at": "2020-01-01T00:00:00Z"},
+    ]
+    assert find_duplicates(albums) == []
+
+
+def test_find_duplicates_detects_same_artist_name_tracks():
+    old = {"service_id": "old1", "name": "Blonde", "artists": [{"name": "Frank Ocean", "id": "fo"}], "total_tracks": 17, "release_date": "2016-08-20", "added_at": "2017-01-01T00:00:00Z"}
+    new = {"service_id": "new1", "name": "Blonde", "artists": [{"name": "Frank Ocean", "id": "fo2"}], "total_tracks": 17, "release_date": "2016-08-20", "added_at": "2023-06-01T00:00:00Z"}
+    unrelated = {"service_id": "u1", "name": "Channel Orange", "artists": [{"name": "Frank Ocean", "id": "fo"}], "total_tracks": 17, "release_date": "2012", "added_at": "2013-01-01T00:00:00Z"}
+
+    results = find_duplicates([old, new, unrelated])
+
+    assert len(results) == 1
+    winner, losers = results[0]
+    assert winner["service_id"] == "new1"
+    assert [l["service_id"] for l in losers] == ["old1"]
+
+
+def test_find_duplicates_ignores_different_track_counts():
+    """Same artist+name but different track count = not a duplicate (deluxe edition)."""
+    standard = {"service_id": "s1", "name": "Rumours", "artists": ["Fleetwood Mac"], "total_tracks": 11, "release_date": "1977", "added_at": "2020-01-01T00:00:00Z"}
+    deluxe = {"service_id": "d1", "name": "Rumours", "artists": ["Fleetwood Mac"], "total_tracks": 22, "release_date": "2013", "added_at": "2020-06-01T00:00:00Z"}
+
+    assert find_duplicates([standard, deluxe]) == []

--- a/backend/tests/test_dedup.py
+++ b/backend/tests/test_dedup.py
@@ -204,3 +204,71 @@ def test_apply_dedup_migrates_tier():
     upsert_arg = metadata_table.upsert.call_args[0][0]
     assert upsert_arg["service_id"] == "new1"
     assert upsert_arg["tier"] == "S"
+
+
+def test_apply_dedup_full_flow_with_collections():
+    """Integration: dedup migrates tier + collection, removes loser, records dedup."""
+    db = MagicMock()
+    tables = {}
+
+    def make_table(name):
+        t = MagicMock()
+        t.select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+        t.insert.return_value.execute.return_value = MagicMock(data=[])
+        t.upsert.return_value.execute.return_value = MagicMock(data=[])
+        t.delete.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+        return t
+
+    def table_router(name):
+        if name not in tables:
+            tables[name] = make_table(name)
+        return tables[name]
+
+    db.table.side_effect = table_router
+
+    # Old album has tier B and is in collection "coll1"
+    am = make_table("album_metadata")
+    new_tier_resp = MagicMock(data=[])
+    old_tier_resp = MagicMock(data=[{"service_id": "old1", "tier": "B", "user_id": "u1"}])
+    am.select.return_value.eq.side_effect = lambda field, val: (
+        MagicMock(eq=lambda f2, v2: old_tier_resp) if val == "old1"
+        else MagicMock(eq=lambda f2, v2: new_tier_resp)
+    )
+    tables["album_metadata"] = am
+
+    ca = make_table("collection_albums")
+    def ca_select_side(*args, **kwargs):
+        mock = MagicMock()
+        def eq1(field, val):
+            mock2 = MagicMock()
+            if field == "service_id" and val == "old1":
+                mock2.eq.return_value.execute.return_value = MagicMock(
+                    data=[{"collection_id": "coll1", "position": 3}]
+                )
+            elif field == "collection_id":
+                mock2.eq.return_value.execute.return_value = MagicMock(data=[])
+            else:
+                mock2.eq.return_value.execute.return_value = MagicMock(data=[])
+            return mock2
+        mock.eq.side_effect = eq1
+        return mock
+    ca.select.side_effect = ca_select_side
+    tables["collection_albums"] = ca
+
+    db.table.side_effect = table_router
+
+    albums = [
+        {"service_id": "old1", "name": "Ctrl", "artists": [{"name": "SZA", "id": "s1"}], "total_tracks": 14, "release_date": "2017-06-09", "added_at": "2017-07-01T00:00:00Z"},
+        {"service_id": "new1", "name": "Ctrl", "artists": [{"name": "SZA", "id": "s2"}], "total_tracks": 14, "release_date": "2017-06-09", "added_at": "2024-01-15T00:00:00Z"},
+        {"service_id": "other", "name": "SOS", "artists": [{"name": "SZA", "id": "s1"}], "total_tracks": 23, "release_date": "2022", "added_at": "2023-01-01T00:00:00Z"},
+    ]
+
+    result = apply_dedup(db, "u1", albums)
+
+    result_ids = [a["service_id"] for a in result]
+    assert "new1" in result_ids
+    assert "other" in result_ids
+    assert "old1" not in result_ids
+    assert len(result) == 2
+
+    tables["deduped_albums"].insert.assert_called_once()

--- a/backend/tests/test_dedup.py
+++ b/backend/tests/test_dedup.py
@@ -1,6 +1,12 @@
 from unittest.mock import MagicMock
 
-from dedup import _dedup_key, _normalize_for_matching, _pick_winner, apply_dedup, find_duplicates
+from dedup import (
+    _dedup_key,
+    _normalize_for_matching,
+    _pick_winner,
+    apply_dedup,
+    find_duplicates,
+)
 
 
 def _mock_db():
@@ -69,7 +75,7 @@ def test_pick_winner_prefers_later_release_date():
     new = {"service_id": "new1", "release_date": "2023-01-01", "added_at": "2021-01-01T00:00:00Z"}
     winner, losers = _pick_winner([old, new])
     assert winner["service_id"] == "new1"
-    assert [l["service_id"] for l in losers] == ["old1"]
+    assert [x["service_id"] for x in losers] == ["old1"]
 
 
 def test_pick_winner_uses_added_at_as_tiebreaker():
@@ -77,7 +83,7 @@ def test_pick_winner_uses_added_at_as_tiebreaker():
     b = {"service_id": "b1", "release_date": "2020-01-01", "added_at": "2023-06-01T00:00:00Z"}
     winner, losers = _pick_winner([a, b])
     assert winner["service_id"] == "b1"
-    assert [l["service_id"] for l in losers] == ["a1"]
+    assert [x["service_id"] for x in losers] == ["a1"]
 
 
 def test_pick_winner_handles_partial_release_dates():
@@ -114,7 +120,7 @@ def test_find_duplicates_detects_same_artist_name_tracks():
     assert len(results) == 1
     winner, losers = results[0]
     assert winner["service_id"] == "new1"
-    assert [l["service_id"] for l in losers] == ["old1"]
+    assert [x["service_id"] for x in losers] == ["old1"]
 
 
 def test_find_duplicates_ignores_different_track_counts():

--- a/backend/tests/test_library.py
+++ b/backend/tests/test_library.py
@@ -578,9 +578,14 @@ def test_sync_complete_records_library_changes():
     )
     cache_mock.upsert.return_value.execute.return_value = MagicMock(data=[])
 
+    deduped_mock = MagicMock()
+    deduped_mock.select.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+
     def table_router(table_name):
         if table_name == "library_changes":
             return changes_mock
+        if table_name == "deduped_albums":
+            return deduped_mock
         return cache_mock
 
     db.table.side_effect = table_router
@@ -609,26 +614,38 @@ def test_sync_complete_skips_changes_when_no_diff():
     cache_albums = [
         {"service_id": "a1", "name": "Album 1", "artists": [], "image_url": None},
     ]
-    db.table.return_value.select.return_value.eq.return_value.execute.return_value = (
-        MagicMock(
-            data=[
-                {
-                    "id": FAKE_USER_ID,
-                    "albums": cache_albums,
-                    "total": 1,
-                    "synced_at": "2026-01-01T00:00:00Z",
-                }
-            ]
-        )
+    cache_mock = MagicMock()
+    cache_mock.select.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[
+            {
+                "id": FAKE_USER_ID,
+                "albums": cache_albums,
+                "total": 1,
+                "synced_at": "2026-01-01T00:00:00Z",
+            }
+        ]
     )
-    db.table.return_value.upsert.return_value.execute.return_value = MagicMock(data=[])
+    cache_mock.upsert.return_value.execute.return_value = MagicMock(data=[])
+
+    deduped_mock = MagicMock()
+    deduped_mock.select.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+
+    changes_mock = MagicMock()
+
+    def table_router(table_name):
+        if table_name == "deduped_albums":
+            return deduped_mock
+        if table_name == "library_changes":
+            return changes_mock
+        return cache_mock
+
+    db.table.side_effect = table_router
     override_db(db)
 
     response = client.post("/library/sync-complete", json={"albums": cache_albums})
     assert response.status_code == 200
 
-    table_calls = [c[0][0] for c in db.table.call_args_list]
-    assert "library_changes" not in table_calls
+    changes_mock.insert.assert_not_called()
 
     clear_overrides()
 
@@ -647,6 +664,49 @@ def test_sync_complete_skips_changes_on_first_sync():
 
     table_calls = [c[0][0] for c in db.table.call_args_list]
     assert "library_changes" not in table_calls
+
+    clear_overrides()
+
+
+def test_sync_complete_filters_suppressed_albums():
+    """Albums in deduped_albums table are filtered out before cache upsert."""
+    db = MagicMock()
+    cache_mock = MagicMock()
+    deduped_mock = MagicMock()
+    changes_mock = MagicMock()
+
+    # No existing cache (first sync)
+    cache_mock.select.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+    cache_mock.upsert.return_value.execute.return_value = MagicMock(data=[])
+
+    # Suppression list: "old1" is a known deduped album
+    deduped_mock.select.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[{"old_service_id": "old1"}]
+    )
+
+    def table_router(name):
+        if name == "deduped_albums":
+            return deduped_mock
+        if name == "library_changes":
+            return changes_mock
+        return cache_mock
+
+    db.table.side_effect = table_router
+    override_db(db)
+
+    albums = [
+        {"service_id": "old1", "name": "Blonde", "artists": [], "total_tracks": 17, "release_date": "2016", "added_at": "2017-01-01T00:00:00Z", "image_url": None},
+        {"service_id": "new1", "name": "Blonde", "artists": [], "total_tracks": 17, "release_date": "2016", "added_at": "2023-01-01T00:00:00Z", "image_url": None},
+    ]
+
+    response = client.post("/library/sync-complete", json={"albums": albums})
+    assert response.status_code == 200
+
+    # The first upsert (before dedup) should only contain non-suppressed album
+    first_upsert = cache_mock.upsert.call_args_list[0][0][0]
+    cached_ids = [a["service_id"] for a in first_upsert["albums"]]
+    assert "old1" not in cached_ids
+    assert "new1" in cached_ids
 
     clear_overrides()
 

--- a/backend/tests/test_library.py
+++ b/backend/tests/test_library.py
@@ -579,7 +579,9 @@ def test_sync_complete_records_library_changes():
     cache_mock.upsert.return_value.execute.return_value = MagicMock(data=[])
 
     deduped_mock = MagicMock()
-    deduped_mock.select.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+    deduped_mock.select.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[]
+    )
 
     def table_router(table_name):
         if table_name == "library_changes":
@@ -628,7 +630,9 @@ def test_sync_complete_skips_changes_when_no_diff():
     cache_mock.upsert.return_value.execute.return_value = MagicMock(data=[])
 
     deduped_mock = MagicMock()
-    deduped_mock.select.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+    deduped_mock.select.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[]
+    )
 
     changes_mock = MagicMock()
 
@@ -676,7 +680,9 @@ def test_sync_complete_filters_suppressed_albums():
     changes_mock = MagicMock()
 
     # No existing cache (first sync)
-    cache_mock.select.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+    cache_mock.select.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[]
+    )
     cache_mock.upsert.return_value.execute.return_value = MagicMock(data=[])
 
     # Suppression list: "old1" is a known deduped album
@@ -695,8 +701,24 @@ def test_sync_complete_filters_suppressed_albums():
     override_db(db)
 
     albums = [
-        {"service_id": "old1", "name": "Blonde", "artists": [], "total_tracks": 17, "release_date": "2016", "added_at": "2017-01-01T00:00:00Z", "image_url": None},
-        {"service_id": "new1", "name": "Blonde", "artists": [], "total_tracks": 17, "release_date": "2016", "added_at": "2023-01-01T00:00:00Z", "image_url": None},
+        {
+            "service_id": "old1",
+            "name": "Blonde",
+            "artists": [],
+            "total_tracks": 17,
+            "release_date": "2016",
+            "added_at": "2017-01-01T00:00:00Z",
+            "image_url": None,
+        },
+        {
+            "service_id": "new1",
+            "name": "Blonde",
+            "artists": [],
+            "total_tracks": 17,
+            "release_date": "2016",
+            "added_at": "2023-01-01T00:00:00Z",
+            "image_url": None,
+        },
     ]
 
     response = client.post("/library/sync-complete", json={"albums": albums})

--- a/docs/plans/2026-04-30-duplicate-album-dedup.md
+++ b/docs/plans/2026-04-30-duplicate-album-dedup.md
@@ -1,0 +1,850 @@
+# Duplicate Album Dedup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Automatically deduplicate albums after library sync when Spotify re-uploads an album under a new ID, migrating user metadata and suppressing the old version from future syncs.
+
+**Architecture:** A new `deduped_albums` Supabase table records old→new mappings. A pure-function dedup module (`backend/dedup.py`) handles matching, winner selection, and metadata migration. The `sync-complete` endpoint calls into this module after upserting the cache. Suppressed albums are filtered out before the cache upsert.
+
+**Tech Stack:** Python 3.12, FastAPI, Supabase (Postgres), pytest
+
+---
+
+### Task 1: Create the `deduped_albums` migration
+
+**Files:**
+- Create: `supabase/migrations/<timestamp>_create_deduped_albums.sql`
+
+- [ ] **Step 1: Generate migration file**
+
+Run: `supabase migration new create_deduped_albums`
+
+- [ ] **Step 2: Write migration SQL**
+
+Edit the generated file to contain:
+
+```sql
+CREATE TABLE public.deduped_albums (
+    old_service_id text NOT NULL,
+    new_service_id text NOT NULL,
+    user_id uuid NOT NULL REFERENCES auth.users(id),
+    deduped_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, old_service_id)
+);
+
+ALTER TABLE public.deduped_albums ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own deduped albums"
+    ON public.deduped_albums FOR SELECT
+    USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own deduped albums"
+    ON public.deduped_albums FOR INSERT
+    WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own deduped albums"
+    ON public.deduped_albums FOR DELETE
+    USING (auth.uid() = user_id);
+```
+
+- [ ] **Step 3: Apply migration to prod**
+
+Run: `supabase db push` or use the Supabase MCP `apply_migration` tool.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add supabase/migrations/*_create_deduped_albums.sql
+git commit -m "Add deduped_albums migration [136]"
+```
+
+---
+
+### Task 2: Implement normalization and matching logic
+
+**Files:**
+- Create: `backend/dedup.py`
+- Create: `backend/tests/test_dedup.py`
+
+- [ ] **Step 1: Write failing test for `_normalize_for_matching`**
+
+In `backend/tests/test_dedup.py`:
+
+```python
+from dedup import _normalize_for_matching
+
+
+def test_normalize_strips_whitespace_and_lowercases():
+    assert _normalize_for_matching("  Led Zeppelin  ") == "led zeppelin"
+
+
+def test_normalize_handles_empty_string():
+    assert _normalize_for_matching("") == ""
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `backend/.venv/bin/python -m pytest backend/tests/test_dedup.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'dedup'`
+
+- [ ] **Step 3: Implement `_normalize_for_matching`**
+
+Create `backend/dedup.py`:
+
+```python
+def _normalize_for_matching(s: str) -> str:
+    """Lowercase and strip whitespace for dedup matching."""
+    return s.strip().lower()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `backend/.venv/bin/python -m pytest backend/tests/test_dedup.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Write failing test for `_dedup_key`**
+
+Append to `backend/tests/test_dedup.py`:
+
+```python
+from dedup import _dedup_key
+
+
+def test_dedup_key_uses_first_artist_name_album_name_track_count():
+    album = {
+        "service_id": "abc",
+        "name": "Abbey Road",
+        "artists": [{"name": "The Beatles", "id": "art1"}],
+        "total_tracks": 17,
+    }
+    assert _dedup_key(album) == ("the beatles", "abbey road", 17)
+
+
+def test_dedup_key_with_string_artists():
+    album = {
+        "service_id": "abc",
+        "name": "Abbey Road",
+        "artists": ["The Beatles"],
+        "total_tracks": 17,
+    }
+    assert _dedup_key(album) == ("the beatles", "abbey road", 17)
+
+
+def test_dedup_key_multiple_artists_uses_first():
+    album = {
+        "service_id": "abc",
+        "name": "Watch the Throne",
+        "artists": [
+            {"name": "JAY-Z", "id": "a1"},
+            {"name": "Kanye West", "id": "a2"},
+        ],
+        "total_tracks": 12,
+    }
+    assert _dedup_key(album) == ("jay-z", "watch the throne", 12)
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+Run: `backend/.venv/bin/python -m pytest backend/tests/test_dedup.py -v`
+Expected: FAIL — `ImportError`
+
+- [ ] **Step 7: Implement `_dedup_key`**
+
+Add to `backend/dedup.py`:
+
+```python
+def _dedup_key(album: dict) -> tuple[str, str, int]:
+    """Return (normalized_first_artist, normalized_name, total_tracks) for matching."""
+    artists = album.get("artists", [])
+    first_artist = ""
+    if artists:
+        a = artists[0]
+        first_artist = a["name"] if isinstance(a, dict) else a
+    return (
+        _normalize_for_matching(first_artist),
+        _normalize_for_matching(album.get("name", "")),
+        album.get("total_tracks", 0),
+    )
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `backend/.venv/bin/python -m pytest backend/tests/test_dedup.py -v`
+Expected: PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add backend/dedup.py backend/tests/test_dedup.py
+git commit -m "Add dedup key normalization and matching [136]"
+```
+
+---
+
+### Task 3: Implement winner selection logic
+
+**Files:**
+- Modify: `backend/dedup.py`
+- Modify: `backend/tests/test_dedup.py`
+
+- [ ] **Step 1: Write failing test for `_pick_winner`**
+
+Append to `backend/tests/test_dedup.py`:
+
+```python
+from dedup import _pick_winner
+
+
+def test_pick_winner_prefers_later_release_date():
+    old = {"service_id": "old1", "release_date": "2020-01-01", "added_at": "2022-06-01T00:00:00Z"}
+    new = {"service_id": "new1", "release_date": "2023-01-01", "added_at": "2021-01-01T00:00:00Z"}
+    winner, loser = _pick_winner([old, new])
+    assert winner["service_id"] == "new1"
+    assert loser["service_id"] == "old1"
+
+
+def test_pick_winner_uses_added_at_as_tiebreaker():
+    a = {"service_id": "a1", "release_date": "2020-01-01", "added_at": "2022-01-01T00:00:00Z"}
+    b = {"service_id": "b1", "release_date": "2020-01-01", "added_at": "2023-06-01T00:00:00Z"}
+    winner, loser = _pick_winner([a, b])
+    assert winner["service_id"] == "b1"
+    assert loser["service_id"] == "a1"
+
+
+def test_pick_winner_handles_partial_release_dates():
+    """Spotify sometimes returns just a year like '2020' instead of full date."""
+    old = {"service_id": "old1", "release_date": "2020", "added_at": "2021-01-01T00:00:00Z"}
+    new = {"service_id": "new1", "release_date": "2023", "added_at": "2022-01-01T00:00:00Z"}
+    winner, loser = _pick_winner([old, new])
+    assert winner["service_id"] == "new1"
+
+
+def test_pick_winner_three_albums_picks_newest():
+    a = {"service_id": "a", "release_date": "2018", "added_at": "2019-01-01T00:00:00Z"}
+    b = {"service_id": "b", "release_date": "2023", "added_at": "2023-06-01T00:00:00Z"}
+    c = {"service_id": "c", "release_date": "2020", "added_at": "2021-01-01T00:00:00Z"}
+    winner, losers = _pick_winner([a, b, c])
+    assert winner["service_id"] == "b"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `backend/.venv/bin/python -m pytest backend/tests/test_dedup.py::test_pick_winner_prefers_later_release_date -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement `_pick_winner`**
+
+Note: `_pick_winner` returns `(winner, loser)` for pairs and `(winner, [losers])` for 3+. Since 3+ duplicates is rare, simplify: always return `(winner, list_of_losers)`. Update tests accordingly.
+
+Add to `backend/dedup.py`:
+
+```python
+def _pick_winner(albums: list[dict]) -> tuple[dict, list[dict]]:
+    """Pick the newest album as winner. Returns (winner, losers).
+
+    Sorts by release_date descending, then added_at descending as tiebreaker.
+    """
+    def sort_key(album):
+        return (album.get("release_date") or "", album.get("added_at") or "")
+
+    ranked = sorted(albums, key=sort_key, reverse=True)
+    return ranked[0], ranked[1:]
+```
+
+- [ ] **Step 4: Update tests to use `(winner, losers)` list return**
+
+Replace the test functions written in Step 1:
+
+```python
+def test_pick_winner_prefers_later_release_date():
+    old = {"service_id": "old1", "release_date": "2020-01-01", "added_at": "2022-06-01T00:00:00Z"}
+    new = {"service_id": "new1", "release_date": "2023-01-01", "added_at": "2021-01-01T00:00:00Z"}
+    winner, losers = _pick_winner([old, new])
+    assert winner["service_id"] == "new1"
+    assert [l["service_id"] for l in losers] == ["old1"]
+
+
+def test_pick_winner_uses_added_at_as_tiebreaker():
+    a = {"service_id": "a1", "release_date": "2020-01-01", "added_at": "2022-01-01T00:00:00Z"}
+    b = {"service_id": "b1", "release_date": "2020-01-01", "added_at": "2023-06-01T00:00:00Z"}
+    winner, losers = _pick_winner([a, b])
+    assert winner["service_id"] == "b1"
+    assert [l["service_id"] for l in losers] == ["a1"]
+
+
+def test_pick_winner_handles_partial_release_dates():
+    old = {"service_id": "old1", "release_date": "2020", "added_at": "2021-01-01T00:00:00Z"}
+    new = {"service_id": "new1", "release_date": "2023", "added_at": "2022-01-01T00:00:00Z"}
+    winner, losers = _pick_winner([old, new])
+    assert winner["service_id"] == "new1"
+
+
+def test_pick_winner_three_albums_picks_newest():
+    a = {"service_id": "a", "release_date": "2018", "added_at": "2019-01-01T00:00:00Z"}
+    b = {"service_id": "b", "release_date": "2023", "added_at": "2023-06-01T00:00:00Z"}
+    c = {"service_id": "c", "release_date": "2020", "added_at": "2021-01-01T00:00:00Z"}
+    winner, losers = _pick_winner([a, b, c])
+    assert winner["service_id"] == "b"
+    assert len(losers) == 2
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `backend/.venv/bin/python -m pytest backend/tests/test_dedup.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/dedup.py backend/tests/test_dedup.py
+git commit -m "Add winner selection logic for dedup [136]"
+```
+
+---
+
+### Task 4: Implement `find_duplicates` grouping function
+
+**Files:**
+- Modify: `backend/dedup.py`
+- Modify: `backend/tests/test_dedup.py`
+
+- [ ] **Step 1: Write failing test for `find_duplicates`**
+
+Append to `backend/tests/test_dedup.py`:
+
+```python
+from dedup import find_duplicates
+
+
+def test_find_duplicates_returns_empty_for_no_dupes():
+    albums = [
+        {"service_id": "a", "name": "Album A", "artists": [{"name": "X", "id": "x"}], "total_tracks": 10, "release_date": "2020", "added_at": "2021-01-01T00:00:00Z"},
+        {"service_id": "b", "name": "Album B", "artists": [{"name": "Y", "id": "y"}], "total_tracks": 8, "release_date": "2019", "added_at": "2020-01-01T00:00:00Z"},
+    ]
+    assert find_duplicates(albums) == []
+
+
+def test_find_duplicates_detects_same_artist_name_tracks():
+    old = {"service_id": "old1", "name": "Blonde", "artists": [{"name": "Frank Ocean", "id": "fo"}], "total_tracks": 17, "release_date": "2016-08-20", "added_at": "2017-01-01T00:00:00Z"}
+    new = {"service_id": "new1", "name": "Blonde", "artists": [{"name": "Frank Ocean", "id": "fo2"}], "total_tracks": 17, "release_date": "2016-08-20", "added_at": "2023-06-01T00:00:00Z"}
+    unrelated = {"service_id": "u1", "name": "Channel Orange", "artists": [{"name": "Frank Ocean", "id": "fo"}], "total_tracks": 17, "release_date": "2012", "added_at": "2013-01-01T00:00:00Z"}
+
+    results = find_duplicates([old, new, unrelated])
+
+    assert len(results) == 1
+    winner, losers = results[0]
+    assert winner["service_id"] == "new1"
+    assert [l["service_id"] for l in losers] == ["old1"]
+
+
+def test_find_duplicates_ignores_different_track_counts():
+    """Same artist+name but different track count = not a duplicate (deluxe edition)."""
+    standard = {"service_id": "s1", "name": "Rumours", "artists": ["Fleetwood Mac"], "total_tracks": 11, "release_date": "1977", "added_at": "2020-01-01T00:00:00Z"}
+    deluxe = {"service_id": "d1", "name": "Rumours", "artists": ["Fleetwood Mac"], "total_tracks": 22, "release_date": "2013", "added_at": "2020-06-01T00:00:00Z"}
+
+    assert find_duplicates([standard, deluxe]) == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `backend/.venv/bin/python -m pytest backend/tests/test_dedup.py::test_find_duplicates_returns_empty_for_no_dupes -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement `find_duplicates`**
+
+Add to `backend/dedup.py`:
+
+```python
+from collections import defaultdict
+
+
+def find_duplicates(albums: list[dict]) -> list[tuple[dict, list[dict]]]:
+    """Group albums by dedup key, return (winner, losers) for each duplicate group.
+
+    Only groups with 2+ albums are returned. Singletons are ignored.
+    """
+    groups: dict[tuple, list[dict]] = defaultdict(list)
+    for album in albums:
+        key = _dedup_key(album)
+        groups[key].append(album)
+
+    results = []
+    for group in groups.values():
+        if len(group) >= 2:
+            winner, losers = _pick_winner(group)
+            results.append((winner, losers))
+    return results
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `backend/.venv/bin/python -m pytest backend/tests/test_dedup.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/dedup.py backend/tests/test_dedup.py
+git commit -m "Add find_duplicates grouping function [136]"
+```
+
+---
+
+### Task 5: Implement metadata migration and dedup recording
+
+**Files:**
+- Modify: `backend/dedup.py`
+- Modify: `backend/tests/test_dedup.py`
+
+- [ ] **Step 1: Write failing test for `apply_dedup`**
+
+`apply_dedup` is the top-level function called by `sync-complete`. It takes `db`, `user_id`, and `albums` (the full cached list), runs dedup, migrates metadata, records to `deduped_albums`, and returns the filtered album list.
+
+Append to `backend/tests/test_dedup.py`:
+
+```python
+from unittest.mock import MagicMock, call
+
+from dedup import apply_dedup
+
+
+def _mock_db():
+    """Mock DB that routes table calls and tracks interactions."""
+    db = MagicMock()
+    tables = {}
+
+    def table_router(name):
+        if name not in tables:
+            tables[name] = MagicMock()
+            # Default: select returns empty
+            tables[name].select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+            tables[name].select.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+            tables[name].upsert.return_value.execute.return_value = MagicMock(data=[])
+            tables[name].insert.return_value.execute.return_value = MagicMock(data=[])
+            tables[name].delete.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+        return tables[name]
+
+    db.table.side_effect = table_router
+    db._tables = tables
+    return db
+
+
+def test_apply_dedup_no_duplicates_returns_albums_unchanged():
+    db = _mock_db()
+    albums = [
+        {"service_id": "a", "name": "A", "artists": [{"name": "X", "id": "x"}], "total_tracks": 10, "release_date": "2020", "added_at": "2021-01-01T00:00:00Z"},
+    ]
+    result = apply_dedup(db, "user1", albums)
+    assert result == albums
+    # No deduped_albums insert
+    db._tables.get("deduped_albums") is None or db._tables["deduped_albums"].insert.assert_not_called()
+
+
+def test_apply_dedup_removes_loser_and_records():
+    db = _mock_db()
+    # No existing tier or collection for the old album
+    albums = [
+        {"service_id": "old1", "name": "Blonde", "artists": [{"name": "Frank Ocean", "id": "fo"}], "total_tracks": 17, "release_date": "2016-08-20", "added_at": "2017-01-01T00:00:00Z"},
+        {"service_id": "new1", "name": "Blonde", "artists": [{"name": "Frank Ocean", "id": "fo2"}], "total_tracks": 17, "release_date": "2016-08-20", "added_at": "2023-06-01T00:00:00Z"},
+    ]
+
+    result = apply_dedup(db, "user1", albums)
+
+    # Only winner remains
+    assert len(result) == 1
+    assert result[0]["service_id"] == "new1"
+
+    # Dedup record inserted
+    deduped_table = db._tables["deduped_albums"]
+    deduped_table.insert.assert_called_once()
+    insert_arg = deduped_table.insert.call_args[0][0]
+    assert insert_arg["old_service_id"] == "old1"
+    assert insert_arg["new_service_id"] == "new1"
+    assert insert_arg["user_id"] == "user1"
+
+
+def test_apply_dedup_migrates_tier():
+    db = _mock_db()
+    # Old album has tier S, new album has no tier
+    metadata_table = db._tables.setdefault("album_metadata", MagicMock())
+
+    # When checking new album's tier: no row
+    # When checking old album's tier: has row
+    tier_responses = {
+        "new1": MagicMock(data=[]),
+        "old1": MagicMock(data=[{"service_id": "old1", "tier": "S", "user_id": "user1"}]),
+    }
+
+    def select_side_effect(*args, **kwargs):
+        eq_mock = MagicMock()
+        def eq_service(field, value):
+            eq2 = MagicMock()
+            def eq_user(field2, value2):
+                return tier_responses.get(value, MagicMock(data=[]))
+            eq2.eq.side_effect = eq_user
+            return eq2
+        eq_mock.eq.side_effect = eq_service
+        return eq_mock
+
+    metadata_table.select.side_effect = select_side_effect
+
+    def table_router(name):
+        if name == "album_metadata":
+            return metadata_table
+        if name not in db._tables:
+            db._tables[name] = MagicMock()
+            db._tables[name].select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+            db._tables[name].insert.return_value.execute.return_value = MagicMock(data=[])
+            db._tables[name].delete.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+        return db._tables[name]
+
+    db.table.side_effect = table_router
+
+    albums = [
+        {"service_id": "old1", "name": "Blonde", "artists": [{"name": "Frank Ocean", "id": "fo"}], "total_tracks": 17, "release_date": "2016", "added_at": "2017-01-01T00:00:00Z"},
+        {"service_id": "new1", "name": "Blonde", "artists": [{"name": "Frank Ocean", "id": "fo2"}], "total_tracks": 17, "release_date": "2016", "added_at": "2023-06-01T00:00:00Z"},
+    ]
+
+    result = apply_dedup(db, "user1", albums)
+    assert len(result) == 1
+
+    # Should have upserted the tier to the new service_id
+    metadata_table.upsert.assert_called_once()
+    upsert_arg = metadata_table.upsert.call_args[0][0]
+    assert upsert_arg["service_id"] == "new1"
+    assert upsert_arg["tier"] == "S"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `backend/.venv/bin/python -m pytest backend/tests/test_dedup.py::test_apply_dedup_no_duplicates_returns_albums_unchanged -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement `apply_dedup`**
+
+Add to `backend/dedup.py`:
+
+```python
+from supabase import Client
+
+
+def _migrate_metadata(db: Client, user_id: str, old_id: str, new_id: str):
+    """Migrate tier and collection memberships from old to new service_id."""
+    # Migrate tier (only if new doesn't have one)
+    new_tier = (
+        db.table("album_metadata")
+        .select("tier")
+        .eq("service_id", new_id)
+        .eq("user_id", user_id)
+        .execute()
+    )
+    old_tier = (
+        db.table("album_metadata")
+        .select("tier")
+        .eq("service_id", old_id)
+        .eq("user_id", user_id)
+        .execute()
+    )
+    if old_tier.data and old_tier.data[0].get("tier"):
+        if not new_tier.data or not new_tier.data[0].get("tier"):
+            db.table("album_metadata").upsert(
+                {"service_id": new_id, "tier": old_tier.data[0]["tier"], "user_id": user_id}
+            ).execute()
+        # Delete old tier row
+        db.table("album_metadata").delete().eq("service_id", old_id).eq("user_id", user_id).execute()
+
+    # Migrate collection memberships
+    old_memberships = (
+        db.table("collection_albums")
+        .select("collection_id, position")
+        .eq("service_id", old_id)
+        .eq("user_id", user_id)
+        .execute()
+    )
+    for membership in old_memberships.data:
+        # Check if new album already in this collection
+        existing = (
+            db.table("collection_albums")
+            .select("service_id")
+            .eq("collection_id", membership["collection_id"])
+            .eq("service_id", new_id)
+            .execute()
+        )
+        if not existing.data:
+            db.table("collection_albums").upsert(
+                {
+                    "collection_id": membership["collection_id"],
+                    "service_id": new_id,
+                    "position": membership["position"],
+                    "user_id": user_id,
+                }
+            ).execute()
+    # Delete old collection memberships
+    db.table("collection_albums").delete().eq("service_id", old_id).eq("user_id", user_id).execute()
+
+
+def apply_dedup(db: Client, user_id: str, albums: list[dict]) -> list[dict]:
+    """Find cross-ID duplicates, migrate metadata, record dedup, return filtered list."""
+    dupes = find_duplicates(albums)
+    if not dupes:
+        return albums
+
+    loser_ids = set()
+    for winner, losers in dupes:
+        for loser in losers:
+            _migrate_metadata(db, user_id, loser["service_id"], winner["service_id"])
+            db.table("deduped_albums").insert(
+                {
+                    "old_service_id": loser["service_id"],
+                    "new_service_id": winner["service_id"],
+                    "user_id": user_id,
+                }
+            ).execute()
+            loser_ids.add(loser["service_id"])
+
+    return [a for a in albums if a["service_id"] not in loser_ids]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `backend/.venv/bin/python -m pytest backend/tests/test_dedup.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/dedup.py backend/tests/test_dedup.py
+git commit -m "Add apply_dedup with metadata migration [136]"
+```
+
+---
+
+### Task 6: Integrate dedup into sync-complete
+
+**Files:**
+- Modify: `backend/routers/library.py:141-166`
+- Modify: `backend/tests/test_library.py`
+
+- [ ] **Step 1: Write failing test for suppression filtering**
+
+Append to `backend/tests/test_library.py`:
+
+```python
+def test_sync_complete_filters_suppressed_albums():
+    """Albums in deduped_albums table are filtered out before cache upsert."""
+    db = MagicMock()
+    cache_mock = MagicMock()
+    deduped_mock = MagicMock()
+    changes_mock = MagicMock()
+
+    # No existing cache (first sync)
+    cache_mock.select.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+    cache_mock.upsert.return_value.execute.return_value = MagicMock(data=[])
+
+    # Suppression list: "old1" is a known deduped album
+    deduped_mock.select.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[{"old_service_id": "old1"}]
+    )
+
+    def table_router(name):
+        if name == "deduped_albums":
+            return deduped_mock
+        if name == "library_changes":
+            return changes_mock
+        return cache_mock
+
+    db.table.side_effect = table_router
+    override_db(db)
+
+    albums = [
+        {"service_id": "old1", "name": "Blonde", "artists": [], "total_tracks": 17, "release_date": "2016", "added_at": "2017-01-01T00:00:00Z", "image_url": None},
+        {"service_id": "new1", "name": "Blonde", "artists": [], "total_tracks": 17, "release_date": "2016", "added_at": "2023-01-01T00:00:00Z", "image_url": None},
+    ]
+
+    response = client.post("/library/sync-complete", json={"albums": albums})
+    assert response.status_code == 200
+
+    # Cache upsert should only contain the non-suppressed album
+    upsert_call = cache_mock.upsert.call_args[0][0]
+    cached_ids = [a["service_id"] for a in upsert_call["albums"]]
+    assert "old1" not in cached_ids
+    assert "new1" in cached_ids
+
+    clear_overrides()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `backend/.venv/bin/python -m pytest backend/tests/test_library.py::test_sync_complete_filters_suppressed_albums -v`
+Expected: FAIL — sync-complete doesn't filter suppressed albums yet
+
+- [ ] **Step 3: Modify sync-complete to add suppression + dedup**
+
+Edit `backend/routers/library.py`, replacing the `sync_complete` function:
+
+```python
+@router.post("/sync-complete")
+def sync_complete(
+    body: SyncCompleteRequest,
+    db: Client = Depends(get_authed_db),
+    user: dict = Depends(get_current_user),
+):
+    user_id = user["user_id"]
+
+    # Filter out previously deduped albums
+    suppressed = db.table("deduped_albums").select("old_service_id").eq("user_id", user_id).execute()
+    suppressed_ids = {r["old_service_id"] for r in suppressed.data}
+    albums = [a for a in body.albums if a["service_id"] not in suppressed_ids]
+
+    # Read current cache to compute diff
+    existing = _get_supabase_cache(db, user_id=user_id)
+    if existing and existing.get("albums"):
+        old_ids = {a["service_id"] for a in existing["albums"]}
+        new_ids = {a["service_id"] for a in albums}
+        added = list(new_ids - old_ids)
+        removed = list(old_ids - new_ids)
+        if added or removed:
+            db.table("library_changes").insert(
+                {
+                    "user_id": user_id,
+                    "added_ids": added,
+                    "removed_ids": removed,
+                }
+            ).execute()
+
+    _save_supabase_cache(db, albums, len(albums), user_id)
+
+    # Run cross-ID dedup on the cached albums
+    from dedup import apply_dedup
+
+    deduped_albums = apply_dedup(db, user_id, albums)
+    if len(deduped_albums) < len(albums):
+        # Re-save cache with losers removed
+        _save_supabase_cache(db, deduped_albums, len(deduped_albums), user_id)
+
+    return {"total": len(deduped_albums)}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `backend/.venv/bin/python -m pytest backend/tests/test_library.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `backend/.venv/bin/python -m pytest backend/tests/ -v`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/routers/library.py backend/tests/test_library.py
+git commit -m "Integrate dedup into sync-complete endpoint [136]"
+```
+
+---
+
+### Task 7: End-to-end integration test
+
+**Files:**
+- Modify: `backend/tests/test_dedup.py`
+
+- [ ] **Step 1: Write integration test for full dedup flow**
+
+Append to `backend/tests/test_dedup.py`:
+
+```python
+def test_apply_dedup_full_flow_with_collections():
+    """Integration: dedup migrates tier + collection, removes loser, records dedup."""
+    db = MagicMock()
+    tables = {}
+
+    def make_table(name):
+        t = MagicMock()
+        t.select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+        t.insert.return_value.execute.return_value = MagicMock(data=[])
+        t.upsert.return_value.execute.return_value = MagicMock(data=[])
+        t.delete.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+        return t
+
+    def table_router(name):
+        if name not in tables:
+            tables[name] = make_table(name)
+        return tables[name]
+
+    db.table.side_effect = table_router
+
+    # Old album has tier B and is in collection "coll1"
+    # Set up album_metadata responses
+    am = make_table("album_metadata")
+    new_tier_resp = MagicMock(data=[])  # new has no tier
+    old_tier_resp = MagicMock(data=[{"service_id": "old1", "tier": "B", "user_id": "u1"}])
+    am.select.return_value.eq.side_effect = lambda field, val: (
+        MagicMock(eq=lambda f2, v2: old_tier_resp) if val == "old1"
+        else MagicMock(eq=lambda f2, v2: new_tier_resp)
+    )
+    tables["album_metadata"] = am
+
+    # Set up collection_albums responses
+    ca = make_table("collection_albums")
+    ca.select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[{"collection_id": "coll1", "position": 3}]
+    )
+    # Check if new album already in collection: no
+    def ca_select_side(*args, **kwargs):
+        mock = MagicMock()
+        def eq1(field, val):
+            mock2 = MagicMock()
+            if field == "service_id" and val == "old1":
+                # Return old album's memberships
+                mock2.eq.return_value.execute.return_value = MagicMock(
+                    data=[{"collection_id": "coll1", "position": 3}]
+                )
+            elif field == "collection_id":
+                # Checking if new album exists in collection
+                mock2.eq.return_value.execute.return_value = MagicMock(data=[])
+            else:
+                mock2.eq.return_value.execute.return_value = MagicMock(data=[])
+            return mock2
+        mock.eq.side_effect = eq1
+        return mock
+    ca.select.side_effect = ca_select_side
+    tables["collection_albums"] = ca
+
+    db.table.side_effect = table_router
+
+    albums = [
+        {"service_id": "old1", "name": "Ctrl", "artists": [{"name": "SZA", "id": "s1"}], "total_tracks": 14, "release_date": "2017-06-09", "added_at": "2017-07-01T00:00:00Z"},
+        {"service_id": "new1", "name": "Ctrl", "artists": [{"name": "SZA", "id": "s2"}], "total_tracks": 14, "release_date": "2017-06-09", "added_at": "2024-01-15T00:00:00Z"},
+        {"service_id": "other", "name": "SOS", "artists": [{"name": "SZA", "id": "s1"}], "total_tracks": 23, "release_date": "2022", "added_at": "2023-01-01T00:00:00Z"},
+    ]
+
+    result = apply_dedup(db, "u1", albums)
+
+    # Only winner + unrelated album remain
+    result_ids = [a["service_id"] for a in result]
+    assert "new1" in result_ids
+    assert "other" in result_ids
+    assert "old1" not in result_ids
+    assert len(result) == 2
+
+    # Dedup record was inserted
+    tables["deduped_albums"].insert.assert_called_once()
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `backend/.venv/bin/python -m pytest backend/tests/test_dedup.py::test_apply_dedup_full_flow_with_collections -v`
+Expected: PASS
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `backend/.venv/bin/python -m pytest backend/tests/ -v`
+Expected: All tests PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/tests/test_dedup.py
+git commit -m "Add integration test for full dedup flow [136]"
+```

--- a/docs/specs/2026-04-30-duplicate-album-dedup-design.md
+++ b/docs/specs/2026-04-30-duplicate-album-dedup-design.md
@@ -1,0 +1,74 @@
+# Duplicate Album Dedup Design [136]
+
+## Problem
+
+Spotify artists sometimes re-upload albums under a new ID. Spotify hides the old version in their UI, but both remain in the user's library. Since we pull from the library API, we display both — resulting in duplicates.
+
+## Solution
+
+Add an automatic dedup step at the end of library sync that detects cross-ID duplicates, keeps the newer version, migrates user metadata, and suppresses the old version from future syncs.
+
+## Matching
+
+Strict match on `(normalized_artist_name, normalized_album_name, total_tracks)`.
+
+Normalization: lowercase, strip leading/trailing whitespace.
+
+This avoids false positives on deluxe editions or remasters that share a name but differ in track count.
+
+## Winner Selection
+
+When a duplicate pair is found, the winner is determined by:
+
+1. Later `release_date` wins
+2. Ties broken by later `added_at`
+
+## Metadata Migration
+
+Before removing the loser, migrate user data from old service_id to new:
+
+1. **album_metadata** (tiers): copy old → new, only if new doesn't already have a tier
+2. **collection_albums**: copy old → new for each collection, only if new isn't already in that collection
+3. Delete old service_id's rows from both tables
+
+## Suppression Table
+
+New `deduped_albums` table:
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `old_service_id` | text | PK (with user_id) |
+| `new_service_id` | text | not null |
+| `user_id` | uuid | PK, FK to auth.users |
+| `deduped_at` | timestamptz | default now() |
+
+RLS policy: users can only read/write their own rows.
+
+## Sync Flow Changes
+
+Current flow:
+1. Fetch pages from Spotify
+2. `sync-complete`: upsert to `library_cache`, compute diff, log to `library_changes`
+
+New flow:
+1. Fetch pages from Spotify (unchanged)
+2. **Filter**: remove any album whose `service_id` appears as `old_service_id` in `deduped_albums` for this user
+3. Upsert to `library_cache` (unchanged)
+4. **Dedup**: group cached albums by (artist, name, track_count), find duplicate groups, for each group: pick winner, migrate metadata, insert `deduped_albums` record, remove loser from cache
+5. Log changes (unchanged)
+
+## Logging
+
+Dedup actions are recorded in the `deduped_albums` table. No UI for this initially — the table serves as an audit trail and enables a future undo feature.
+
+## No UI Changes
+
+Dedup is fully transparent to the user. Duplicates simply stop appearing after sync.
+
+## Testing
+
+- Unit tests for normalization logic
+- Unit tests for winner selection (release_date priority, added_at tiebreaker)
+- Unit tests for metadata migration (tier copy, collection copy, no-overwrite semantics)
+- Integration test for full dedup flow: sync with duplicates → verify one remains, metadata migrated, dedup record created
+- Integration test for suppression: re-sync after dedup → verify old album filtered out

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -226,13 +226,15 @@ export default function App() {
           body: JSON.stringify({ albums: accumulated }),
         }, sessionRef.current)
 
-        // Now update display — only replace if sync returned data
-        if (accumulated.length > 0) {
-          setAlbums(accumulated)
+        // Re-fetch authoritative album list (server may have deduped)
+        const freshResp = await apiFetch('/library/albums', {}, sessionRef.current).then(r => r.json())
+        const freshAlbums = freshResp.albums || accumulated
+        if (freshAlbums.length > 0) {
+          setAlbums(freshAlbums)
           try {
             localStorage.setItem(CACHE_KEY, JSON.stringify({
-              albums: accumulated,
-              total: accumulated.length,
+              albums: freshAlbums,
+              total: freshAlbums.length,
               cachedAt: new Date().toISOString(),
             }))
           } catch { /* storage full or unavailable */ }

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1028,9 +1028,10 @@ describe('App — library sync loop', () => {
         })
       }
       if (url.includes('/library/albums') && !url.includes('/tracks')) {
+        // Post-sync re-fetch returns the deduped authoritative list
         return Promise.resolve({
           ok: true,
-          json: () => Promise.resolve({ albums: [], total: 0, last_synced: null }),
+          json: () => Promise.resolve({ albums: [SYNCED_ALBUM], total: 1, last_synced: new Date().toISOString() }),
         })
       }
       if (url.includes('/collections')) {

--- a/supabase/migrations/20260501035429_create_deduped_albums.sql
+++ b/supabase/migrations/20260501035429_create_deduped_albums.sql
@@ -1,0 +1,21 @@
+CREATE TABLE public.deduped_albums (
+    old_service_id text NOT NULL,
+    new_service_id text NOT NULL,
+    user_id uuid NOT NULL REFERENCES auth.users(id),
+    deduped_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, old_service_id)
+);
+
+ALTER TABLE public.deduped_albums ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own deduped albums"
+    ON public.deduped_albums FOR SELECT
+    USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own deduped albums"
+    ON public.deduped_albums FOR INSERT
+    WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own deduped albums"
+    ON public.deduped_albums FOR DELETE
+    USING (auth.uid() = user_id);


### PR DESCRIPTION
## Summary

- Adds automatic dedup step at end of library sync that detects Spotify re-uploaded albums (same artist + name + track count, different service_id)
- Keeps the newer version (by release_date, then added_at), migrates tiers and collection memberships from old to new
- Records dedup mappings in new `deduped_albums` table; suppresses old albums from future syncs
- 230/230 backend tests passing

## Changes

- `backend/dedup.py` — pure-function dedup module (normalization, matching, winner selection, metadata migration)
- `backend/routers/library.py` — sync-complete now filters suppressed albums and runs dedup
- `supabase/migrations/20260501035429_create_deduped_albums.sql` — new table with RLS (already applied to prod)
- `backend/tests/test_dedup.py` — 16 tests covering all dedup logic
- `backend/tests/test_library.py` — updated sync-complete tests for new dedup integration

## Test plan

- [x] All 230 backend tests pass
- [ ] Deploy preview and sync library — verify no duplicate albums appear
- [ ] Manually check `deduped_albums` table for any recorded dedup actions
- [ ] Verify existing tiers and collections are preserved after dedup

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)