### PR TITLE
Collections overhaul: hierarchical tags, sidebar tree, list/grid [125]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ Avoid patterns that trigger sandbox approval prompts:
 - **`main` is production** — merging to main triggers a Vercel production deploy to live users. Treat every merge as a production release. Never push, force-push, or merge to main without passing CI and user approval.
 - **Issue-first**: every code change starts from a GitHub issue
 - **Branch from issue**: branch name is `<issue-number>-<short-title>`, e.g. `18-library-sync-wipes-cache`. No `feat/` prefix.
+- **Session bootstrap**: at the start of every session, check your branch and see if it's got an associated GitHub issue for context.
 - **Draft PR immediately**: push branch and open a draft PR linking the issue before writing code. This gives visibility and a place for discussion.
 - **Auto-commit** when all tests pass — no need to ask permission
 - **One commit per agent task** — each background agent should commit its own work when done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ Avoid patterns that trigger sandbox approval prompts:
 - **`main` is production** — merging to main triggers a Vercel production deploy to live users. Treat every merge as a production release. Never push, force-push, or merge to main without passing CI and user approval.
 - **Issue-first**: every code change starts from a GitHub issue
 - **Branch from issue**: branch name is `<issue-number>-<short-title>`, e.g. `18-library-sync-wipes-cache`. No `feat/` prefix.
+- **Session bootstrap**: at the start of any session, check `git branch --show-current`. If the branch name starts with `<digits>-` (e.g. `152-collection-open-crash`), that prefix is the GitHub issue number for the work in this worktree. Fetch the issue body via `gh issue view <num> --repo toofanian/bummer` before doing anything else, and treat it as the source of truth for what to build/fix. This applies even if the user's first message is terse or seems unrelated — confirm scope against the issue first.
 - **Draft PR immediately**: push branch and open a draft PR linking the issue before writing code. This gives visibility and a place for discussion.
 - **Auto-commit** when all tests pass — no need to ask permission
 - **One commit per agent task** — each background agent should commit its own work when done

--- a/backend/main.py
+++ b/backend/main.py
@@ -20,6 +20,7 @@ from routers import (
     library,
     metadata,
     playback,
+    tags,
 )
 
 load_dotenv()
@@ -76,6 +77,7 @@ app.include_router(metadata.router)
 app.include_router(playback.router)
 app.include_router(digest.router)
 app.include_router(export.router)
+app.include_router(tags.router)
 
 
 @app.get("/health")

--- a/backend/routers/metadata.py
+++ b/backend/routers/metadata.py
@@ -1,7 +1,8 @@
 from typing import Literal
+from uuid import UUID
 
 import spotipy
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
 import routers.library as library_module
@@ -41,6 +42,10 @@ class BulkAddBody(BaseModel):
 
 class CoverBody(BaseModel):
     cover_album_id: str | None
+
+
+class CollectionTagsSet(BaseModel):
+    tag_ids: list[UUID]
 
 
 # --- Bulk ---
@@ -359,3 +364,92 @@ def get_collection_albums(
     album_map = {a["service_id"]: a for a in cached_albums if a["service_id"] in ids}
     albums = [album_map[sid] for sid in ordered_ids if sid in album_map]
     return {"albums": albums}
+
+
+# --- Collection <-> Tag associations ---
+
+
+@router.get("/collections/{collection_id}/tags")
+def list_collection_tags(
+    collection_id: str,
+    db=Depends(get_authed_db),
+    user: dict = Depends(get_current_user),
+):
+    user_id = user["user_id"]
+    coll = (
+        db.table("collections")
+        .select("id")
+        .eq("id", collection_id)
+        .eq("user_id", user_id)
+        .execute()
+    )
+    if not coll.data:
+        raise HTTPException(status_code=404, detail="Collection not found")
+    res = (
+        db.table("collection_tags")
+        .select("tag_id, tags(id, name, parent_tag_id, position)")
+        .eq("collection_id", collection_id)
+        .execute()
+    )
+    return [row["tags"] for row in res.data if row.get("tags")]
+
+
+@router.put("/collections/{collection_id}/tags")
+def set_collection_tags(
+    collection_id: str,
+    body: CollectionTagsSet,
+    db=Depends(get_authed_db),
+    user: dict = Depends(get_current_user),
+):
+    user_id = user["user_id"]
+    coll = (
+        db.table("collections")
+        .select("id")
+        .eq("id", collection_id)
+        .eq("user_id", user_id)
+        .execute()
+    )
+    if not coll.data:
+        raise HTTPException(status_code=404, detail="Collection not found")
+    if body.tag_ids:
+        owned = (
+            db.table("tags")
+            .select("id")
+            .in_("id", [str(t) for t in body.tag_ids])
+            .eq("user_id", user_id)
+            .execute()
+        )
+        if len(owned.data) != len(body.tag_ids):
+            raise HTTPException(status_code=400, detail="One or more tag_ids invalid")
+    db.table("collection_tags").delete().eq("collection_id", collection_id).execute()
+    if body.tag_ids:
+        rows = [
+            {"collection_id": collection_id, "tag_id": str(t)} for t in body.tag_ids
+        ]
+        db.table("collection_tags").insert(rows).execute()
+    return {"ok": True}
+
+
+@router.get("/tags/{tag_id}/collections")
+def list_collections_for_tag(
+    tag_id: str,
+    db=Depends(get_authed_db),
+    user: dict = Depends(get_current_user),
+):
+    user_id = user["user_id"]
+    tag = (
+        db.table("tags")
+        .select("id")
+        .eq("id", tag_id)
+        .eq("user_id", user_id)
+        .execute()
+    )
+    if not tag.data:
+        raise HTTPException(status_code=404, detail="Tag not found")
+    res = (
+        db.table("collection_tags")
+        .select("collection_id")
+        .eq("tag_id", tag_id)
+        .execute()
+    )
+    return [{"collection_id": row["collection_id"]} for row in res.data]

--- a/backend/routers/metadata.py
+++ b/backend/routers/metadata.py
@@ -363,7 +363,7 @@ def get_collection_albums(
     cached_albums = library_module.get_album_cache(db, user_id=user_id)
     album_map = {a["service_id"]: a for a in cached_albums if a["service_id"] in ids}
     albums = [album_map[sid] for sid in ordered_ids if sid in album_map]
-    return {"albums": albums}
+    return {"albums": library_module._flatten_artists_for_response(albums)}
 
 
 # --- Collection <-> Tag associations ---

--- a/backend/routers/tags.py
+++ b/backend/routers/tags.py
@@ -1,0 +1,155 @@
+"""Tag CRUD endpoints — forest of user-scoped tags with parent_tag_id + position."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from auth_middleware import get_authed_db, get_current_user
+
+router = APIRouter(tags=["tags"])
+
+
+class TagCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+    parent_tag_id: UUID | None = None
+
+
+class TagRename(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+
+
+class TagMove(BaseModel):
+    parent_tag_id: UUID | None = None
+    position: int = Field(..., ge=0)
+
+
+class TagReorder(BaseModel):
+    parent_tag_id: UUID | None = None
+    tag_ids: list[UUID]
+
+
+@router.get("/tags")
+def list_tags(
+    db=Depends(get_authed_db),
+    user: dict = Depends(get_current_user),
+):
+    res = (
+        db.table("tags")
+        .select("id, name, parent_tag_id, position, created_at")
+        .eq("user_id", user["user_id"])
+        .order("position")
+        .execute()
+    )
+    return res.data
+
+
+@router.post("/tags", status_code=201)
+def create_tag(
+    body: TagCreate,
+    db=Depends(get_authed_db),
+    user: dict = Depends(get_current_user),
+):
+    user_id = user["user_id"]
+    # Compute next position among siblings (parent_tag_id may be NULL → use .is_)
+    sib_query = db.table("tags").select("position").eq("user_id", user_id)
+    if body.parent_tag_id is None:
+        sib_query = sib_query.is_("parent_tag_id", "null")
+    else:
+        sib_query = sib_query.eq("parent_tag_id", str(body.parent_tag_id))
+    sibling_rows = sib_query.execute().data
+    next_pos = max((s["position"] for s in sibling_rows), default=-1) + 1
+
+    payload = {
+        "user_id": user_id,
+        "name": body.name,
+        "parent_tag_id": str(body.parent_tag_id) if body.parent_tag_id else None,
+        "position": next_pos,
+    }
+    try:
+        res = db.table("tags").insert(payload).execute()
+    except Exception as e:
+        msg = str(e).lower()
+        if "duplicate" in msg or "unique" in msg:
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                "Tag with that name already exists at this level",
+            ) from e
+        raise
+    return res.data[0]
+
+
+# NOTE: /tags/reorder must be declared BEFORE /tags/{tag_id} so FastAPI does not
+# match "reorder" as a UUID path param.
+@router.put("/tags/reorder")
+def reorder_siblings(
+    body: TagReorder,
+    db=Depends(get_authed_db),
+    user: dict = Depends(get_current_user),
+):
+    user_id = user["user_id"]
+    for idx, tag_id in enumerate(body.tag_ids):
+        db.table("tags").update({"position": idx}).eq("id", str(tag_id)).eq(
+            "user_id", user_id
+        ).execute()
+    return {"ok": True}
+
+
+@router.patch("/tags/{tag_id}")
+def rename_tag(
+    tag_id: UUID,
+    body: TagRename,
+    db=Depends(get_authed_db),
+    user: dict = Depends(get_current_user),
+):
+    res = (
+        db.table("tags")
+        .update({"name": body.name})
+        .eq("id", str(tag_id))
+        .eq("user_id", user["user_id"])
+        .execute()
+    )
+    if not res.data:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Tag not found")
+    return res.data[0]
+
+
+@router.delete("/tags/{tag_id}", status_code=204)
+def delete_tag(
+    tag_id: UUID,
+    db=Depends(get_authed_db),
+    user: dict = Depends(get_current_user),
+):
+    res = (
+        db.table("tags")
+        .delete()
+        .eq("id", str(tag_id))
+        .eq("user_id", user["user_id"])
+        .execute()
+    )
+    if not res.data:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Tag not found")
+
+
+@router.put("/tags/{tag_id}/move")
+def move_tag(
+    tag_id: UUID,
+    body: TagMove,
+    db=Depends(get_authed_db),
+    user: dict = Depends(get_current_user),
+):
+    res = (
+        db.table("tags")
+        .update(
+            {
+                "parent_tag_id": str(body.parent_tag_id) if body.parent_tag_id else None,
+                "position": body.position,
+            }
+        )
+        .eq("id", str(tag_id))
+        .eq("user_id", user["user_id"])
+        .execute()
+    )
+    if not res.data:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Tag not found")
+    return res.data[0]

--- a/backend/tests/test_metadata.py
+++ b/backend/tests/test_metadata.py
@@ -909,6 +909,233 @@ def test_remove_album_from_collection_scopes_by_user_id():
     clear_overrides()
 
 
+# --- Collection <-> Tag association tests ---
+
+
+def test_list_collection_tags_empty():
+    db = mock_db()
+    # Collection ownership lookup
+    db.table.return_value.select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[{"id": "col-uuid-1"}]
+    )
+    # collection_tags lookup (.select().eq().execute())
+    db.table.return_value.select.return_value.eq.return_value.execute.return_value = (
+        MagicMock(data=[])
+    )
+    override_db(db)
+    override_spotify(mock_spotify())
+
+    response = client.get("/collections/col-uuid-1/tags")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+    clear_overrides()
+
+
+def test_list_collection_tags_returns_tag_objects():
+    db = mock_db()
+    db.table.return_value.select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[{"id": "col-uuid-1"}]
+    )
+    db.table.return_value.select.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[
+            {
+                "tag_id": "tag-1",
+                "tags": {
+                    "id": "tag-1",
+                    "name": "Mood",
+                    "parent_tag_id": None,
+                    "position": 0,
+                },
+            }
+        ]
+    )
+    override_db(db)
+    override_spotify(mock_spotify())
+
+    response = client.get("/collections/col-uuid-1/tags")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["name"] == "Mood"
+
+    clear_overrides()
+
+
+def test_list_collection_tags_404_when_collection_not_owned():
+    db = mock_db()
+    db.table.return_value.select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[]
+    )
+    override_db(db)
+    override_spotify(mock_spotify())
+
+    response = client.get("/collections/col-uuid-1/tags")
+
+    assert response.status_code == 404
+
+    clear_overrides()
+
+
+def test_set_collection_tags_replaces_existing():
+    db = mock_db()
+    # Collection ownership: .select("id").eq("id",...).eq("user_id",...).execute()
+    # Tags ownership: .select("id").in_("id",...).eq("user_id",...).execute()
+    # We need the .eq().eq() chain to return the collection, AND the .in_().eq() chain
+    # to return all tags as owned.
+    tag_a = "11111111-1111-1111-1111-111111111111"
+    tag_b = "22222222-2222-2222-2222-222222222222"
+    db.table.return_value.select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[{"id": "col-uuid-1"}]
+    )
+    db.table.return_value.select.return_value.in_.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[{"id": tag_a}, {"id": tag_b}]
+    )
+    # Delete existing rows: .delete().eq().execute()
+    db.table.return_value.delete.return_value.eq.return_value.execute.return_value = (
+        MagicMock(data=[])
+    )
+    db.table.return_value.insert.return_value.execute.return_value = MagicMock(data=[])
+    override_db(db)
+    override_spotify(mock_spotify())
+
+    response = client.put(
+        "/collections/col-uuid-1/tags",
+        json={"tag_ids": [tag_a, tag_b]},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    # Verify delete then insert called
+    assert db.table.return_value.delete.called
+    insert_call = db.table.return_value.insert.call_args[0][0]
+    assert len(insert_call) == 2
+    assert {row["tag_id"] for row in insert_call} == {tag_a, tag_b}
+
+    clear_overrides()
+
+
+def test_set_collection_tags_clears_when_empty_array():
+    db = mock_db()
+    db.table.return_value.select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[{"id": "col-uuid-1"}]
+    )
+    db.table.return_value.delete.return_value.eq.return_value.execute.return_value = (
+        MagicMock(data=[])
+    )
+    override_db(db)
+    override_spotify(mock_spotify())
+
+    response = client.put("/collections/col-uuid-1/tags", json={"tag_ids": []})
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    # delete called, insert NOT called
+    assert db.table.return_value.delete.called
+    assert not db.table.return_value.insert.called
+
+    clear_overrides()
+
+
+def test_set_collection_tags_validates_tag_ownership():
+    """Passing a tag the user does not own → 400."""
+    db = mock_db()
+    db.table.return_value.select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[{"id": "col-uuid-1"}]
+    )
+    # Only one of two requested tags is owned
+    db.table.return_value.select.return_value.in_.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[{"id": "11111111-1111-1111-1111-111111111111"}]
+    )
+    override_db(db)
+    override_spotify(mock_spotify())
+
+    response = client.put(
+        "/collections/col-uuid-1/tags",
+        json={
+            "tag_ids": [
+                "11111111-1111-1111-1111-111111111111",
+                "22222222-2222-2222-2222-222222222222",
+            ]
+        },
+    )
+
+    assert response.status_code == 400
+
+    clear_overrides()
+
+
+def test_set_collection_tags_404_when_collection_not_owned():
+    db = mock_db()
+    db.table.return_value.select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[]
+    )
+    override_db(db)
+    override_spotify(mock_spotify())
+
+    response = client.put("/collections/col-uuid-1/tags", json={"tag_ids": []})
+
+    assert response.status_code == 404
+
+    clear_overrides()
+
+
+def test_list_collections_for_tag():
+    db = mock_db()
+    # Tag ownership lookup: .select("id").eq("id",...).eq("user_id",...).execute()
+    db.table.return_value.select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[{"id": "tag-1"}]
+    )
+    # collection_tags lookup
+    db.table.return_value.select.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[{"collection_id": "col-uuid-1"}, {"collection_id": "col-uuid-2"}]
+    )
+    override_db(db)
+    override_spotify(mock_spotify())
+
+    response = client.get("/tags/11111111-1111-1111-1111-111111111111/collections")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    assert {r["collection_id"] for r in data} == {"col-uuid-1", "col-uuid-2"}
+
+    clear_overrides()
+
+
+def test_list_collections_for_tag_404_when_not_owned():
+    db = mock_db()
+    db.table.return_value.select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[]
+    )
+    override_db(db)
+    override_spotify(mock_spotify())
+
+    response = client.get("/tags/11111111-1111-1111-1111-111111111111/collections")
+
+    assert response.status_code == 404
+
+    clear_overrides()
+
+
+def test_user_isolation_for_collection_tags():
+    """A request as OTHER_USER must apply OTHER_USER_ID in ownership filters."""
+    db = mock_db()
+    db.table.return_value.select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[]
+    )
+    _override_as_other_user(db)
+
+    client.get("/collections/col-uuid-1/tags")
+
+    all_calls_str = str(db.mock_calls)
+    assert OTHER_USER_ID in all_calls_str
+
+    clear_overrides()
+
+
 def test_list_collections_works_without_spotify_token():
     """list_collections should not depend on Spotify — it only reads from DB."""
     db = mock_db(execute_data=[COLLECTION])

--- a/backend/tests/test_metadata.py
+++ b/backend/tests/test_metadata.py
@@ -406,6 +406,38 @@ def test_get_collection_albums_returns_empty_when_collection_empty(monkeypatch):
     clear_overrides()
 
 
+def test_get_collection_albums_flattens_artist_objects(monkeypatch):
+    """Regression for #152 — cached albums store artists as {id, name} dicts;
+    the endpoint must flatten them to plain strings before returning so the
+    frontend doesn't render objects as React children."""
+    import routers.library as library_module
+
+    cached = [
+        {
+            "service_id": "id1",
+            "name": "Album One",
+            "artists": [{"id": "art-1", "name": "Cached Artist"}],
+            "release_date": "2020",
+            "total_tracks": 10,
+            "image_url": None,
+            "added_at": "2021-01-01T00:00:00Z",
+        },
+    ]
+    monkeypatch.setattr(
+        library_module, "get_album_cache", lambda db=None, user_id=None: cached
+    )
+
+    db = mock_db(execute_data=[{"service_id": "id1"}])
+    override_db(db)
+
+    response = client.get("/collections/col-uuid-1/albums")
+
+    assert response.status_code == 200
+    assert response.json()["albums"][0]["artists"] == ["Cached Artist"]
+
+    clear_overrides()
+
+
 # --- Collection rename ---
 
 

--- a/backend/tests/test_tags.py
+++ b/backend/tests/test_tags.py
@@ -1,0 +1,373 @@
+"""Tests for /tags CRUD endpoints (Task 2 of collections overhaul)."""
+
+from unittest.mock import MagicMock
+
+from fastapi.testclient import TestClient
+
+from auth_middleware import get_authed_db, get_current_user
+from main import app
+
+client = TestClient(app)
+
+FAKE_USER_ID = "test-user-id-123"
+FAKE_USER = {"user_id": FAKE_USER_ID, "token": "fake-token"}
+
+OTHER_USER_ID = "other-user-id-456"
+OTHER_USER = {"user_id": OTHER_USER_ID, "token": "other-fake-token"}
+
+
+def make_db():
+    """Return a generic MagicMock supabase client; tests configure chains as needed."""
+    return MagicMock()
+
+
+def override_db(db, user=FAKE_USER):
+    app.dependency_overrides[get_authed_db] = lambda: db
+    app.dependency_overrides[get_current_user] = lambda: user
+
+
+def clear_overrides():
+    app.dependency_overrides.clear()
+
+
+# --- list_tags ---
+
+
+def test_list_tags_empty_returns_empty_array():
+    db = make_db()
+    db.table.return_value.select.return_value.eq.return_value.order.return_value.execute.return_value = MagicMock(
+        data=[]
+    )
+    override_db(db)
+
+    response = client.get("/tags")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+    clear_overrides()
+
+
+def test_list_tags_returns_user_tags():
+    rows = [
+        {
+            "id": "tag-1",
+            "name": "Mood",
+            "parent_tag_id": None,
+            "position": 0,
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+    ]
+    db = make_db()
+    db.table.return_value.select.return_value.eq.return_value.order.return_value.execute.return_value = MagicMock(
+        data=rows
+    )
+    override_db(db)
+
+    response = client.get("/tags")
+
+    assert response.status_code == 200
+    assert response.json() == rows
+    # Confirm user_id scoping
+    db.table.return_value.select.return_value.eq.assert_called_with(
+        "user_id", FAKE_USER_ID
+    )
+
+    clear_overrides()
+
+
+# --- create_tag ---
+
+
+def test_create_root_tag_assigns_position_zero():
+    db = make_db()
+    # No existing siblings
+    db.table.return_value.select.return_value.eq.return_value.is_.return_value.execute.return_value = MagicMock(
+        data=[]
+    )
+    inserted = {
+        "id": "tag-new",
+        "name": "Mood",
+        "parent_tag_id": None,
+        "position": 0,
+        "created_at": "2026-01-01T00:00:00Z",
+    }
+    db.table.return_value.insert.return_value.execute.return_value = MagicMock(
+        data=[inserted]
+    )
+    override_db(db)
+
+    response = client.post("/tags", json={"name": "Mood"})
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["position"] == 0
+    assert data["name"] == "Mood"
+    # Verify insert payload included position 0
+    insert_call = db.table.return_value.insert.call_args[0][0]
+    assert insert_call["position"] == 0
+    assert insert_call["parent_tag_id"] is None
+    assert insert_call["user_id"] == FAKE_USER_ID
+
+    clear_overrides()
+
+
+def test_create_sibling_tag_assigns_next_position():
+    db = make_db()
+    # Existing root siblings at positions 0, 1
+    db.table.return_value.select.return_value.eq.return_value.is_.return_value.execute.return_value = MagicMock(
+        data=[{"position": 0}, {"position": 1}]
+    )
+    db.table.return_value.insert.return_value.execute.return_value = MagicMock(
+        data=[
+            {
+                "id": "tag-new",
+                "name": "Energy",
+                "parent_tag_id": None,
+                "position": 2,
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+        ]
+    )
+    override_db(db)
+
+    response = client.post("/tags", json={"name": "Energy"})
+
+    assert response.status_code == 201
+    insert_call = db.table.return_value.insert.call_args[0][0]
+    assert insert_call["position"] == 2
+
+    clear_overrides()
+
+
+def test_create_child_tag_with_parent_id():
+    db = make_db()
+    # No existing siblings under this parent
+    db.table.return_value.select.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[]
+    )
+    parent_id = "11111111-1111-1111-1111-111111111111"
+    db.table.return_value.insert.return_value.execute.return_value = MagicMock(
+        data=[
+            {
+                "id": "tag-child",
+                "name": "Chill",
+                "parent_tag_id": parent_id,
+                "position": 0,
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+        ]
+    )
+    override_db(db)
+
+    response = client.post(
+        "/tags", json={"name": "Chill", "parent_tag_id": parent_id}
+    )
+
+    assert response.status_code == 201
+    insert_call = db.table.return_value.insert.call_args[0][0]
+    assert insert_call["parent_tag_id"] == parent_id
+
+    clear_overrides()
+
+
+def test_create_duplicate_sibling_name_returns_409():
+    db = make_db()
+    db.table.return_value.select.return_value.eq.return_value.is_.return_value.execute.return_value = MagicMock(
+        data=[]
+    )
+    db.table.return_value.insert.return_value.execute.side_effect = Exception(
+        "duplicate key value violates unique constraint"
+    )
+    override_db(db)
+
+    response = client.post("/tags", json={"name": "Mood"})
+
+    assert response.status_code == 409
+
+    clear_overrides()
+
+
+# --- rename_tag ---
+
+
+def test_rename_tag():
+    db = make_db()
+    db.table.return_value.update.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[
+            {
+                "id": "tag-1",
+                "name": "New Name",
+                "parent_tag_id": None,
+                "position": 0,
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+        ]
+    )
+    override_db(db)
+
+    tag_id = "11111111-1111-1111-1111-111111111111"
+    response = client.patch(f"/tags/{tag_id}", json={"name": "New Name"})
+
+    assert response.status_code == 200
+    assert response.json()["name"] == "New Name"
+
+    clear_overrides()
+
+
+def test_rename_tag_not_found_returns_404():
+    db = make_db()
+    db.table.return_value.update.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[]
+    )
+    override_db(db)
+
+    tag_id = "11111111-1111-1111-1111-111111111111"
+    response = client.patch(f"/tags/{tag_id}", json={"name": "x"})
+
+    assert response.status_code == 404
+
+    clear_overrides()
+
+
+# --- delete_tag ---
+
+
+def test_delete_tag_cascades_to_children():
+    """DB cascade is enforced by the FK ON DELETE CASCADE; endpoint just deletes the row."""
+    db = make_db()
+    db.table.return_value.delete.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[{"id": "tag-1"}]
+    )
+    override_db(db)
+
+    tag_id = "11111111-1111-1111-1111-111111111111"
+    response = client.delete(f"/tags/{tag_id}")
+
+    assert response.status_code == 204
+
+    clear_overrides()
+
+
+def test_delete_tag_not_found_returns_404():
+    db = make_db()
+    db.table.return_value.delete.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[]
+    )
+    override_db(db)
+
+    tag_id = "11111111-1111-1111-1111-111111111111"
+    response = client.delete(f"/tags/{tag_id}")
+
+    assert response.status_code == 404
+
+    clear_overrides()
+
+
+# --- move_tag ---
+
+
+def test_move_tag_changes_parent_and_position():
+    db = make_db()
+    new_parent = "22222222-2222-2222-2222-222222222222"
+    db.table.return_value.update.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[
+            {
+                "id": "tag-1",
+                "name": "Moved",
+                "parent_tag_id": new_parent,
+                "position": 3,
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+        ]
+    )
+    override_db(db)
+
+    tag_id = "11111111-1111-1111-1111-111111111111"
+    response = client.put(
+        f"/tags/{tag_id}/move",
+        json={"parent_tag_id": new_parent, "position": 3},
+    )
+
+    assert response.status_code == 200
+    update_payload = db.table.return_value.update.call_args[0][0]
+    assert update_payload["parent_tag_id"] == new_parent
+    assert update_payload["position"] == 3
+
+    clear_overrides()
+
+
+# --- reorder ---
+
+
+def test_reorder_siblings():
+    db = make_db()
+    db.table.return_value.update.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[]
+    )
+    override_db(db)
+
+    response = client.put(
+        "/tags/reorder",
+        json={
+            "parent_tag_id": None,
+            "tag_ids": [
+                "11111111-1111-1111-1111-111111111111",
+                "22222222-2222-2222-2222-222222222222",
+                "33333333-3333-3333-3333-333333333333",
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    # Three update calls, one per id
+    assert db.table.return_value.update.call_count == 3
+
+    clear_overrides()
+
+
+# --- ownership / user isolation ---
+
+
+def test_user_cannot_see_other_users_tags():
+    """list_tags must filter by current user's id, so a request as OTHER_USER
+    queries with OTHER_USER_ID."""
+    db = make_db()
+    db.table.return_value.select.return_value.eq.return_value.order.return_value.execute.return_value = MagicMock(
+        data=[]
+    )
+    override_db(db, user=OTHER_USER)
+
+    response = client.get("/tags")
+
+    assert response.status_code == 200
+    db.table.return_value.select.return_value.eq.assert_called_with(
+        "user_id", OTHER_USER_ID
+    )
+
+    clear_overrides()
+
+
+def test_rename_tag_scopes_by_user_id():
+    db = make_db()
+    db.table.return_value.update.return_value.eq.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[
+            {
+                "id": "tag-1",
+                "name": "x",
+                "parent_tag_id": None,
+                "position": 0,
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+        ]
+    )
+    override_db(db, user=OTHER_USER)
+
+    tag_id = "11111111-1111-1111-1111-111111111111"
+    client.patch(f"/tags/{tag_id}", json={"name": "x"})
+
+    all_calls_str = str(db.mock_calls)
+    assert OTHER_USER_ID in all_calls_str
+
+    clear_overrides()

--- a/docs/plans/2026-05-04-collections-overhaul.md
+++ b/docs/plans/2026-05-04-collections-overhaul.md
@@ -1,0 +1,967 @@
+# Collections Overhaul Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace flat collections list with hierarchical-tag browsing, denser layouts (list + grid), shadcn primitives, and a centralized membership reducer — preserving the serving-platter add flow.
+
+**Architecture:** New `tags` and `collection_tags` Postgres tables (forest of tags, many-to-many to collections). New backend endpoints under `/tags` and `/collections/{id}/tags`. Frontend gets a `TagTreeSidebar` (desktop) / `TagDrillPage` (mobile), `CollectionGrid` and `CollectionList` views with a toggle, `TagPickerInput` for inline tag-add, and a `TagManagerPage`. shadcn/ui adopted for tree, toggle, card, command, and badge primitives. App.jsx scattered `albumCollectionMap` mutations consolidated into `useCollectionMembership`.
+
+**Tech Stack:** FastAPI, Supabase Postgres, React + Vite, Tailwind, shadcn/ui, dnd-kit, Vitest, pytest
+
+**Spec:** `docs/specs/2026-05-04-collections-overhaul-design.md`
+
+---
+
+## Phase 1 — Backend (tags data model + endpoints)
+
+### Task 1: Create `tags` and `collection_tags` migration
+
+**Files:**
+- Create: `supabase/migrations/YYYYMMDDHHMMSS_create_tags.sql`
+
+- [ ] **Step 1: Generate migration file**
+
+```bash
+supabase migration new create_tags
+```
+
+- [ ] **Step 2: Write the migration SQL**
+
+```sql
+CREATE TABLE public.tags (
+    id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+    user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    name text NOT NULL,
+    parent_tag_id uuid REFERENCES public.tags(id) ON DELETE CASCADE,
+    position integer NOT NULL DEFAULT 0,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE NULLS NOT DISTINCT (user_id, parent_tag_id, name)
+);
+
+CREATE INDEX idx_tags_user_parent ON public.tags(user_id, parent_tag_id, position);
+
+ALTER TABLE public.tags ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users read own tags" ON public.tags
+    FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "Users insert own tags" ON public.tags
+    FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users update own tags" ON public.tags
+    FOR UPDATE USING (auth.uid() = user_id);
+CREATE POLICY "Users delete own tags" ON public.tags
+    FOR DELETE USING (auth.uid() = user_id);
+
+CREATE TABLE public.collection_tags (
+    collection_id uuid NOT NULL REFERENCES public.collections(id) ON DELETE CASCADE,
+    tag_id uuid NOT NULL REFERENCES public.tags(id) ON DELETE CASCADE,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (collection_id, tag_id)
+);
+
+CREATE INDEX idx_collection_tags_tag ON public.collection_tags(tag_id);
+
+ALTER TABLE public.collection_tags ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users read own collection_tags" ON public.collection_tags
+    FOR SELECT USING (
+        EXISTS (SELECT 1 FROM public.collections c WHERE c.id = collection_id AND c.user_id = auth.uid())
+    );
+CREATE POLICY "Users insert own collection_tags" ON public.collection_tags
+    FOR INSERT WITH CHECK (
+        EXISTS (SELECT 1 FROM public.collections c WHERE c.id = collection_id AND c.user_id = auth.uid())
+        AND EXISTS (SELECT 1 FROM public.tags t WHERE t.id = tag_id AND t.user_id = auth.uid())
+    );
+CREATE POLICY "Users delete own collection_tags" ON public.collection_tags
+    FOR DELETE USING (
+        EXISTS (SELECT 1 FROM public.collections c WHERE c.id = collection_id AND c.user_id = auth.uid())
+    );
+```
+
+- [ ] **Step 3: Apply migration to prod via Supabase MCP `apply_migration`**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add supabase/migrations/
+git commit -m "feat: create tags + collection_tags tables [125]"
+```
+
+---
+
+### Task 2: Add tag CRUD endpoints (`/tags` GET, POST, PATCH, DELETE, PUT /move, PUT /reorder)
+
+**Files:**
+- Create: `backend/routers/tags.py`
+- Modify: `backend/main.py` (register router)
+- Test: `backend/tests/test_tags.py`
+
+- [ ] **Step 1: Write failing tests for full CRUD**
+
+Add `backend/tests/test_tags.py` with tests:
+- `test_list_tags_empty_returns_empty_array`
+- `test_create_root_tag_assigns_position_zero`
+- `test_create_sibling_tag_assigns_next_position`
+- `test_create_child_tag_with_parent_id`
+- `test_create_duplicate_sibling_name_returns_409`
+- `test_rename_tag`
+- `test_delete_tag_cascades_to_children`
+- `test_move_tag_changes_parent_and_position`
+- `test_reorder_siblings`
+- `test_user_cannot_see_other_users_tags`
+
+Use the existing test fixtures (`authed_client`, `other_user_client`) from `backend/tests/conftest.py`.
+
+- [ ] **Step 2: Run tests, verify all FAIL**
+
+```bash
+backend/.venv/bin/python -m pytest backend/tests/test_tags.py -v
+```
+
+- [ ] **Step 3: Implement `backend/routers/tags.py`**
+
+```python
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from typing import Optional
+from uuid import UUID
+
+from backend.deps import get_user_supabase, get_user_id
+
+router = APIRouter(prefix="/tags", tags=["tags"])
+
+
+class TagCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=100)
+    parent_tag_id: Optional[UUID] = None
+
+
+class TagRename(BaseModel):
+    name: str = Field(min_length=1, max_length=100)
+
+
+class TagMove(BaseModel):
+    parent_tag_id: Optional[UUID] = None
+    position: int = Field(ge=0)
+
+
+class TagReorder(BaseModel):
+    parent_tag_id: Optional[UUID] = None
+    tag_ids: list[UUID]
+
+
+@router.get("")
+def list_tags(supabase=Depends(get_user_supabase), user_id=Depends(get_user_id)):
+    res = (
+        supabase.table("tags")
+        .select("id, name, parent_tag_id, position, created_at")
+        .eq("user_id", user_id)
+        .order("position")
+        .execute()
+    )
+    return res.data
+
+
+@router.post("", status_code=201)
+def create_tag(body: TagCreate, supabase=Depends(get_user_supabase), user_id=Depends(get_user_id)):
+    # Compute next position among siblings
+    siblings = (
+        supabase.table("tags")
+        .select("position")
+        .eq("user_id", user_id)
+        .eq("parent_tag_id" if body.parent_tag_id else "parent_tag_id", str(body.parent_tag_id) if body.parent_tag_id else None)
+    )
+    if body.parent_tag_id is None:
+        siblings = siblings.is_("parent_tag_id", "null")
+    else:
+        siblings = siblings.eq("parent_tag_id", str(body.parent_tag_id))
+    sibling_rows = siblings.execute().data
+    next_pos = max((s["position"] for s in sibling_rows), default=-1) + 1
+
+    payload = {
+        "user_id": user_id,
+        "name": body.name,
+        "parent_tag_id": str(body.parent_tag_id) if body.parent_tag_id else None,
+        "position": next_pos,
+    }
+    try:
+        res = supabase.table("tags").insert(payload).execute()
+    except Exception as e:
+        if "duplicate" in str(e).lower() or "unique" in str(e).lower():
+            raise HTTPException(status.HTTP_409_CONFLICT, "Tag with that name already exists at this level")
+        raise
+    return res.data[0]
+
+
+@router.patch("/{tag_id}")
+def rename_tag(tag_id: UUID, body: TagRename, supabase=Depends(get_user_supabase), user_id=Depends(get_user_id)):
+    res = (
+        supabase.table("tags")
+        .update({"name": body.name})
+        .eq("id", str(tag_id))
+        .eq("user_id", user_id)
+        .execute()
+    )
+    if not res.data:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Tag not found")
+    return res.data[0]
+
+
+@router.delete("/{tag_id}", status_code=204)
+def delete_tag(tag_id: UUID, supabase=Depends(get_user_supabase), user_id=Depends(get_user_id)):
+    res = (
+        supabase.table("tags")
+        .delete()
+        .eq("id", str(tag_id))
+        .eq("user_id", user_id)
+        .execute()
+    )
+    if not res.data:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Tag not found")
+
+
+@router.put("/{tag_id}/move")
+def move_tag(tag_id: UUID, body: TagMove, supabase=Depends(get_user_supabase), user_id=Depends(get_user_id)):
+    res = (
+        supabase.table("tags")
+        .update({
+            "parent_tag_id": str(body.parent_tag_id) if body.parent_tag_id else None,
+            "position": body.position,
+        })
+        .eq("id", str(tag_id))
+        .eq("user_id", user_id)
+        .execute()
+    )
+    if not res.data:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Tag not found")
+    return res.data[0]
+
+
+@router.put("/reorder")
+def reorder_siblings(body: TagReorder, supabase=Depends(get_user_supabase), user_id=Depends(get_user_id)):
+    for idx, tag_id in enumerate(body.tag_ids):
+        supabase.table("tags").update({"position": idx}).eq("id", str(tag_id)).eq("user_id", user_id).execute()
+    return {"ok": True}
+```
+
+Register router in `backend/main.py`:
+
+```python
+from backend.routers import tags as tags_router
+app.include_router(tags_router.router)
+```
+
+- [ ] **Step 4: Run tests, verify PASS**
+
+```bash
+backend/.venv/bin/python -m pytest backend/tests/test_tags.py -v
+```
+
+- [ ] **Step 5: Lint**
+
+```bash
+backend/.venv/bin/ruff check backend/ --fix
+backend/.venv/bin/ruff format backend/
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/
+git commit -m "feat: add tags CRUD endpoints [125]"
+```
+
+---
+
+### Task 3: Add collection ↔ tag association endpoints
+
+**Files:**
+- Modify: `backend/routers/metadata.py` (add three handlers)
+- Test: `backend/tests/test_collections.py` (add new test cases)
+
+Endpoints:
+- `GET /collections/{id}/tags` — list tags on a collection
+- `PUT /collections/{id}/tags` body `{ tag_ids: [...] }` — replace full tag set
+- `GET /tags/{id}/collections` — list collections that have this tag (direct only)
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `backend/tests/test_collections.py`:
+- `test_list_collection_tags_empty`
+- `test_set_collection_tags_replaces_existing`
+- `test_set_collection_tags_clears_when_empty_array`
+- `test_set_collection_tags_validates_tag_ownership` (passing another user's tag → 404 or 400)
+- `test_list_collections_for_tag`
+- `test_user_isolation_for_collection_tags`
+
+- [ ] **Step 2: Run, verify FAIL**
+
+```bash
+backend/.venv/bin/python -m pytest backend/tests/test_collections.py -v -k "tag"
+```
+
+- [ ] **Step 3: Implement handlers in `backend/routers/metadata.py`**
+
+```python
+class CollectionTagsSet(BaseModel):
+    tag_ids: list[UUID]
+
+
+@router.get("/collections/{collection_id}/tags")
+def list_collection_tags(collection_id: UUID, supabase=Depends(get_user_supabase), user_id=Depends(get_user_id)):
+    # Verify ownership
+    coll = supabase.table("collections").select("id").eq("id", str(collection_id)).eq("user_id", user_id).execute()
+    if not coll.data:
+        raise HTTPException(404, "Collection not found")
+    res = (
+        supabase.table("collection_tags")
+        .select("tag_id, tags(id, name, parent_tag_id, position)")
+        .eq("collection_id", str(collection_id))
+        .execute()
+    )
+    return [row["tags"] for row in res.data]
+
+
+@router.put("/collections/{collection_id}/tags")
+def set_collection_tags(collection_id: UUID, body: CollectionTagsSet, supabase=Depends(get_user_supabase), user_id=Depends(get_user_id)):
+    coll = supabase.table("collections").select("id").eq("id", str(collection_id)).eq("user_id", user_id).execute()
+    if not coll.data:
+        raise HTTPException(404, "Collection not found")
+    # Validate all tag_ids belong to user
+    if body.tag_ids:
+        owned = (
+            supabase.table("tags")
+            .select("id")
+            .in_("id", [str(t) for t in body.tag_ids])
+            .eq("user_id", user_id)
+            .execute()
+        )
+        if len(owned.data) != len(body.tag_ids):
+            raise HTTPException(400, "One or more tag_ids invalid")
+    # Wipe and reinsert
+    supabase.table("collection_tags").delete().eq("collection_id", str(collection_id)).execute()
+    if body.tag_ids:
+        rows = [{"collection_id": str(collection_id), "tag_id": str(t)} for t in body.tag_ids]
+        supabase.table("collection_tags").insert(rows).execute()
+    return {"ok": True}
+
+
+@router.get("/tags/{tag_id}/collections")
+def list_collections_for_tag(tag_id: UUID, supabase=Depends(get_user_supabase), user_id=Depends(get_user_id)):
+    tag = supabase.table("tags").select("id").eq("id", str(tag_id)).eq("user_id", user_id).execute()
+    if not tag.data:
+        raise HTTPException(404, "Tag not found")
+    res = (
+        supabase.table("collection_tags")
+        .select("collection_id")
+        .eq("tag_id", str(tag_id))
+        .execute()
+    )
+    return [{"collection_id": row["collection_id"]} for row in res.data]
+```
+
+- [ ] **Step 4: Run tests, verify PASS**
+
+- [ ] **Step 5: Lint + Commit**
+
+```bash
+backend/.venv/bin/ruff check backend/ --fix && backend/.venv/bin/ruff format backend/
+git add backend/
+git commit -m "feat: add collection<->tag association endpoints [125]"
+```
+
+---
+
+## Phase 2 — Frontend foundation
+
+### Task 4: Install shadcn/ui + required components
+
+**Files:**
+- Modify: `frontend/package.json`
+- Create: `frontend/src/components/ui/*` (shadcn output)
+- Modify: `frontend/tailwind.config.js` (shadcn config additions)
+
+- [ ] **Step 1: Initialize shadcn**
+
+```bash
+npx --prefix frontend shadcn@latest init
+```
+
+Use existing Tailwind config; choose "JavaScript" not TypeScript; CSS variables yes; output dir `src/components/ui`.
+
+- [ ] **Step 2: Install needed components**
+
+```bash
+npx --prefix frontend shadcn@latest add collapsible toggle-group card command badge button dialog
+```
+
+- [ ] **Step 3: Verify dev server still starts**
+
+```bash
+make dev-bg MAIN_REPO=<main-repo-path>
+```
+
+Check `http://localhost:5173` loads. Stop with `make stop`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/
+git commit -m "chore: install shadcn/ui base components [125]"
+```
+
+---
+
+### Task 5: Add `useCollectionMembership` hook
+
+**Files:**
+- Create: `frontend/src/hooks/useCollectionMembership.js`
+- Test: `frontend/src/hooks/useCollectionMembership.test.js`
+- Modify: `frontend/src/App.jsx` — replace scattered `setAlbumCollectionMap` calls with hook actions
+
+- [ ] **Step 1: Write failing tests**
+
+Test cases:
+- `addAlbumsToCollection(collectionId, albumIds)` updates map for each
+- `removeAlbumFromCollection(collectionId, albumId)` removes entry
+- `setCollectionMembership(collectionId, albumIds)` replaces full set
+- `deleteCollection(collectionId)` removes collectionId from every album's list
+- Returns stable references (memoized) when state unchanged
+
+- [ ] **Step 2: Run, verify FAIL**
+
+```bash
+npx --prefix frontend vitest --run useCollectionMembership
+```
+
+- [ ] **Step 3: Implement**
+
+```js
+// frontend/src/hooks/useCollectionMembership.js
+import { useCallback, useState } from 'react';
+
+export function useCollectionMembership(initial = {}) {
+  const [map, setMap] = useState(initial);
+
+  const addAlbumsToCollection = useCallback((collectionId, albumIds) => {
+    setMap((prev) => {
+      const next = { ...prev };
+      for (const id of albumIds) {
+        const list = next[id] ?? [];
+        if (!list.includes(collectionId)) next[id] = [...list, collectionId];
+      }
+      return next;
+    });
+  }, []);
+
+  const removeAlbumFromCollection = useCallback((collectionId, albumId) => {
+    setMap((prev) => {
+      const list = prev[albumId];
+      if (!list) return prev;
+      const filtered = list.filter((id) => id !== collectionId);
+      return { ...prev, [albumId]: filtered };
+    });
+  }, []);
+
+  const setCollectionMembership = useCallback((collectionId, albumIds) => {
+    setMap((prev) => {
+      const next = {};
+      // Strip collectionId from all entries
+      for (const [aid, list] of Object.entries(prev)) {
+        const stripped = list.filter((id) => id !== collectionId);
+        if (stripped.length) next[aid] = stripped;
+      }
+      // Add to each new album
+      for (const aid of albumIds) {
+        next[aid] = [...(next[aid] ?? []), collectionId];
+      }
+      return next;
+    });
+  }, []);
+
+  const deleteCollection = useCallback((collectionId) => {
+    setMap((prev) => {
+      const next = {};
+      for (const [aid, list] of Object.entries(prev)) {
+        const stripped = list.filter((id) => id !== collectionId);
+        if (stripped.length) next[aid] = stripped;
+      }
+      return next;
+    });
+  }, []);
+
+  return {
+    albumCollectionMap: map,
+    setAlbumCollectionMap: setMap,
+    addAlbumsToCollection,
+    removeAlbumFromCollection,
+    setCollectionMembership,
+    deleteCollection,
+  };
+}
+```
+
+- [ ] **Step 4: Run tests, verify PASS**
+
+- [ ] **Step 5: Refactor App.jsx**
+
+Replace existing `useState(albumCollectionMap)` with `useCollectionMembership()`. Replace inline `setAlbumCollectionMap(...)` mutations in `handleBulkAdd`, `handleToggleCollection`, `handleDeleteCollection`, `handleFetchCollectionAlbums`, `handleEnterCollection` with the named action calls.
+
+Run full frontend test suite to confirm no regressions:
+
+```bash
+npx --prefix frontend vitest --run
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/
+git commit -m "refactor: centralize collection membership in hook [125]"
+```
+
+---
+
+## Phase 3 — Tag UI
+
+### Task 6: Build `TagTreeSidebar` component (desktop)
+
+**Files:**
+- Create: `frontend/src/components/TagTreeSidebar.jsx`
+- Test: `frontend/src/components/TagTreeSidebar.test.jsx`
+- Create: `frontend/src/lib/tagTree.js` (tree-building helpers)
+- Test: `frontend/src/lib/tagTree.test.js`
+
+- [ ] **Step 1: Write failing tests for `tagTree.js` helpers**
+
+```js
+// buildTagTree(flatTags) -> [{ ...tag, children: [...] }]
+// getDescendantIds(tree, tagId) -> Set<string>
+// findNode(tree, tagId) -> node | null
+```
+
+- [ ] **Step 2: Implement `tagTree.js`**
+
+```js
+export function buildTagTree(flatTags) {
+  const byId = new Map();
+  for (const t of flatTags) byId.set(t.id, { ...t, children: [] });
+  const roots = [];
+  for (const node of byId.values()) {
+    if (node.parent_tag_id && byId.has(node.parent_tag_id)) {
+      byId.get(node.parent_tag_id).children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+  const sortRec = (nodes) => {
+    nodes.sort((a, b) => a.position - b.position);
+    nodes.forEach((n) => sortRec(n.children));
+  };
+  sortRec(roots);
+  return roots;
+}
+
+export function getDescendantIds(tree, tagId) {
+  const result = new Set();
+  const node = findNode(tree, tagId);
+  if (!node) return result;
+  const walk = (n) => {
+    result.add(n.id);
+    n.children.forEach(walk);
+  };
+  walk(node);
+  return result;
+}
+
+export function findNode(tree, tagId) {
+  for (const node of tree) {
+    if (node.id === tagId) return node;
+    const sub = findNode(node.children, tagId);
+    if (sub) return sub;
+  }
+  return null;
+}
+```
+
+- [ ] **Step 3: Write failing tests for `TagTreeSidebar`**
+
+Tests:
+- Renders "All" root + flat tag list
+- Expand/collapse parent shows/hides children
+- Click tag fires `onSelect(tagId)`
+- Selected tag has highlighted state
+- Empty state shows "No tags yet" + "Manage tags" link
+
+- [ ] **Step 4: Implement `TagTreeSidebar.jsx`**
+
+```jsx
+import { useState } from 'react';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { ChevronRight } from 'lucide-react';
+import { buildTagTree } from '@/lib/tagTree';
+
+function TagNode({ node, selectedId, onSelect, depth = 0 }) {
+  const [open, setOpen] = useState(true);
+  const hasChildren = node.children.length > 0;
+  const isSelected = selectedId === node.id;
+
+  return (
+    <div>
+      <div
+        className={`flex items-center gap-1 px-2 py-1 rounded cursor-pointer hover:bg-bg-elevated ${isSelected ? 'bg-bg-elevated text-text font-medium' : 'text-text-dim'}`}
+        style={{ paddingLeft: `${depth * 12 + 8}px` }}
+        onClick={() => onSelect(node.id)}
+      >
+        {hasChildren ? (
+          <button
+            onClick={(e) => { e.stopPropagation(); setOpen(!open); }}
+            className="w-4 h-4 flex items-center justify-center"
+          >
+            <ChevronRight className={`w-3 h-3 transition-transform ${open ? 'rotate-90' : ''}`} />
+          </button>
+        ) : (
+          <span className="w-4" />
+        )}
+        <span className="text-sm truncate">{node.name}</span>
+      </div>
+      {hasChildren && open && (
+        <div>
+          {node.children.map((child) => (
+            <TagNode key={child.id} node={child} selectedId={selectedId} onSelect={onSelect} depth={depth + 1} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function TagTreeSidebar({ tags, selectedTagId, onSelect, onOpenManager }) {
+  const tree = buildTagTree(tags);
+  return (
+    <aside className="w-56 border-r border-border h-full flex flex-col">
+      <div className="p-2 flex-1 overflow-y-auto">
+        <div
+          className={`px-2 py-1 rounded cursor-pointer hover:bg-bg-elevated text-sm ${selectedTagId === null ? 'bg-bg-elevated font-medium' : 'text-text-dim'}`}
+          onClick={() => onSelect(null)}
+        >
+          All
+        </div>
+        {tree.map((node) => (
+          <TagNode key={node.id} node={node} selectedId={selectedTagId} onSelect={onSelect} />
+        ))}
+        {tags.length === 0 && (
+          <div className="px-2 py-4 text-xs text-text-dim">No tags yet</div>
+        )}
+      </div>
+      <button
+        onClick={onOpenManager}
+        className="border-t border-border px-3 py-2 text-xs text-text-dim hover:text-text text-left"
+      >
+        Manage tags
+      </button>
+    </aside>
+  );
+}
+```
+
+- [ ] **Step 5: Tests PASS, commit**
+
+```bash
+git add frontend/
+git commit -m "feat: add TagTreeSidebar + tagTree helpers [125]"
+```
+
+---
+
+### Task 7: Build `TagPickerInput` (inline tag chip editor on collection)
+
+**Files:**
+- Create: `frontend/src/components/TagPickerInput.jsx`
+- Test: `frontend/src/components/TagPickerInput.test.jsx`
+
+Behavior: shows current tags as removable chips, an autocomplete combobox below (using shadcn `Command`) listing existing tags filtered by query. Enter creates a new tag if no exact match exists. Calls `onChange(tagIds)`.
+
+- [ ] **Step 1: Write tests**
+
+- Renders existing tag chips
+- Removing a chip fires `onChange` without that tag id
+- Typing filters dropdown
+- Selecting from dropdown adds tag id
+- Pressing Enter on novel name calls `onCreate(name)` and adds returned tag
+
+- [ ] **Step 2: Implement** using shadcn `Command` + `Badge`. Component props:
+
+```jsx
+<TagPickerInput
+  allTags={tags}
+  selectedTagIds={[...]}
+  onChange={(nextIds) => ...}
+  onCreate={async (name) => /* returns { id } */}
+/>
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "feat: add TagPickerInput component [125]"
+```
+
+---
+
+### Task 8: Build `TagManagerPage`
+
+**Files:**
+- Create: `frontend/src/components/TagManagerPage.jsx`
+- Test: `frontend/src/components/TagManagerPage.test.jsx`
+
+Renders the tag tree as an editable surface: each node has rename / delete / add-child / drag-to-reparent. Uses dnd-kit for reorder + reparent.
+
+- [ ] **Step 1: Write tests** — rename calls onRename, delete shows confirm + calls onDelete, add-child calls onCreate(parentId), reorder calls onReorder([ids], parentId).
+
+- [ ] **Step 2: Implement** with the same tree-walk pattern as `TagTreeSidebar` but each node has inline-edit + action buttons. Use existing `confirmingId` pattern from CollectionsPane for delete confirmation.
+
+- [ ] **Step 3: Commit**
+
+---
+
+## Phase 4 — Collection layouts
+
+### Task 9: Build `CollectionGrid` + `CollectionCard`
+
+**Files:**
+- Create: `frontend/src/components/CollectionGrid.jsx`
+- Create: `frontend/src/components/CollectionCard.jsx`
+- Test: `frontend/src/components/CollectionCard.test.jsx`
+- Test: `frontend/src/components/CollectionGrid.test.jsx`
+
+`CollectionCard` renders a 2x2 mosaic of the first 4 albums (or single pinned cover when set). Below the mosaic: collection name only. Click → `onOpen(collection)`. Right-click / long-press → context menu (rename, delete, manage tags).
+
+`CollectionGrid` is responsive: 2 columns mobile, 3-4 desktop. Uses CSS grid.
+
+- [ ] **Step 1: Write tests**
+
+CollectionCard:
+- Renders 2x2 mosaic from `albums` prop
+- Renders single pinned cover when `cover_album_id` set
+- Renders gray placeholder when no albums
+- Click fires `onOpen`
+
+CollectionGrid:
+- Renders one card per collection
+- Empty state when collections empty
+
+- [ ] **Step 2: Implement**
+
+```jsx
+// CollectionCard.jsx
+export function CollectionCard({ collection, albums, onOpen }) {
+  const pinned = collection.cover_album_id
+    ? albums.find((a) => a.service_id === collection.cover_album_id)
+    : null;
+  const mosaicAlbums = pinned ? [pinned] : albums.slice(0, 4);
+
+  return (
+    <button
+      onClick={() => onOpen(collection)}
+      className="flex flex-col gap-2 text-left group"
+    >
+      <div className="aspect-square rounded-md overflow-hidden bg-bg-elevated grid grid-cols-2 grid-rows-2 gap-px">
+        {mosaicAlbums.length === 0 ? (
+          <div className="col-span-2 row-span-2 bg-bg-elevated" />
+        ) : pinned ? (
+          <img src={pinned.image_url} alt="" className="col-span-2 row-span-2 w-full h-full object-cover" />
+        ) : (
+          mosaicAlbums.map((a, i) => (
+            <img key={a.service_id} src={a.image_url} alt="" className="w-full h-full object-cover" />
+          ))
+        )}
+      </div>
+      <div className="text-sm text-text truncate group-hover:text-text-hover">{collection.name}</div>
+    </button>
+  );
+}
+```
+
+- [ ] **Step 3: Commit**
+
+---
+
+### Task 10: Build `CollectionList` (denser replacement)
+
+**Files:**
+- Create: `frontend/src/components/CollectionList.jsx`
+- Test: `frontend/src/components/CollectionList.test.jsx`
+
+Compact rows: small art strip (28px), name, count. Hover reveals overflow menu. ~40px row height (vs current 62px). Drag-to-reorder via dnd-kit, same as current pane.
+
+- [ ] **Step 1: Tests** — renders rows, click opens, drag reorders, overflow menu (rename/delete/manage tags).
+
+- [ ] **Step 2: Implement**, lifting the row interaction logic from current `CollectionsPane.jsx` but with denser styling.
+
+- [ ] **Step 3: Commit**
+
+---
+
+### Task 11: Build `ViewToggle`
+
+**Files:**
+- Create: `frontend/src/components/ViewToggle.jsx`
+- Test: `frontend/src/components/ViewToggle.test.jsx`
+
+Two-button shadcn `ToggleGroup` (List / Grid icons). Persists choice to `localStorage` under `bummer.collectionsView`.
+
+- [ ] **Step 1-3:** Tests + implementation + commit.
+
+---
+
+## Phase 5 — Wire it all together
+
+### Task 12: Rebuild `CollectionsPane` as orchestrator
+
+**Files:**
+- Modify: `frontend/src/components/CollectionsPane.jsx`
+- Modify: `frontend/src/App.jsx` (props it passes)
+
+New CollectionsPane composition:
+
+```jsx
+<div className="flex h-full">
+  <TagTreeSidebar
+    tags={tags}
+    selectedTagId={selectedTagId}
+    onSelect={setSelectedTagId}
+    onOpenManager={() => onView('tag-manager')}
+  />
+  <div className="flex-1 flex flex-col overflow-hidden">
+    <div className="flex items-center justify-between p-3 border-b border-border">
+      <ViewToggle value={viewMode} onChange={setViewMode} />
+      <button onClick={onCreate}>+ New Collection</button>
+    </div>
+    <div className="flex-1 overflow-y-auto p-3">
+      {viewMode === 'grid' ? (
+        <CollectionGrid collections={filteredCollections} onOpen={onEnter} />
+      ) : (
+        <CollectionList collections={filteredCollections} onOpen={onEnter} ... />
+      )}
+    </div>
+    {/* Existing serving platter rows */}
+    <RecentlyAddedRow ... />
+    <RecentlyPlayedRow ... />
+  </div>
+</div>
+```
+
+`filteredCollections` = collections where `selectedTagId` is null OR collection has any tag in `getDescendantIds(tree, selectedTagId)`.
+
+- [ ] **Step 1: Update CollectionsPane tests** — add tests for filtering, view toggling.
+
+- [ ] **Step 2: Implement composition + filter logic.**
+
+- [ ] **Step 3: Wire `tags`, `selectedTagId`, `viewMode` state into App.jsx.** Fetch tags on app load (parallel with collections); store in App state; pass down.
+
+- [ ] **Step 4: Run full frontend test suite, fix regressions.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat: rebuild CollectionsPane with sidebar + grid/list [125]"
+```
+
+---
+
+### Task 13: Add tag-manager view route
+
+**Files:**
+- Modify: `frontend/src/App.jsx` — add `'tag-manager'` to view union, render `TagManagerPage` when active
+- Modify: `frontend/src/components/CollectionDetailHeader.jsx` — embed `TagPickerInput` below description
+
+- [ ] **Step 1: Tests** — clicking "Manage tags" in sidebar switches view; collection detail saves tag changes via PUT `/collections/{id}/tags`.
+
+- [ ] **Step 2: Implement.**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "feat: wire tag manager + collection tag editor [125]"
+```
+
+---
+
+## Phase 6 — Mobile
+
+### Task 14: Mobile drill-down (`TagDrillPage`)
+
+**Files:**
+- Create: `frontend/src/components/TagDrillPage.jsx`
+- Test: `frontend/src/components/TagDrillPage.test.jsx`
+- Modify: `frontend/src/components/CollectionsPane.jsx` (mobile branch swaps in TagDrillPage instead of sidebar)
+
+`TagDrillPage` shows: parent breadcrumb (back button to parent tag or "All"), child tags as tappable rows, then collections at this tag's level (CollectionGrid in 2-col mode). Serving platter rows at bottom only on the root ("All") view.
+
+- [ ] **Step 1: Tests** — root shows root tags + all collections; tapping a tag drills in; back button returns; serving platter only shown at root.
+
+- [ ] **Step 2: Implement** using same `buildTagTree` + `findNode` helpers.
+
+- [ ] **Step 3: Wire mobile branch in CollectionsPane** (existing `useIsMobile()` or media query — match current pattern).
+
+- [ ] **Step 4: Commit**
+
+---
+
+## Phase 7 — Cleanup
+
+### Task 15: Remove dead code from old CollectionsPane
+
+**Files:**
+- Modify: `frontend/src/components/CollectionsPane.jsx`
+
+Delete:
+- Old desktop-row JSX (replaced by CollectionList)
+- Old mobile-row JSX (replaced by CollectionGrid + drill-down)
+- `artMap` side-effect block — moved into CollectionList / CollectionGrid where albums prop arrives ready to use
+- Old rename/delete inline state — moved into CollectionList row component
+
+Confirm by greping for any remaining references and running full tests:
+
+```bash
+npx --prefix frontend vitest --run
+```
+
+- [ ] **Step 1: Delete dead code, run tests, fix any breakages.**
+
+- [ ] **Step 2: Commit**
+
+```bash
+git commit -m "refactor: remove dead CollectionsPane row code [125]"
+```
+
+---
+
+### Task 16: Local preview + PR
+
+- [ ] **Step 1: Start dev servers**
+
+```bash
+make dev-bg MAIN_REPO=<main-repo>
+```
+
+- [ ] **Step 2: Tell user to verify at `http://localhost:5173`** — both desktop (sidebar + grid + list toggle) and mobile (drill-down).
+
+- [ ] **Step 3: After user approves, push branch and update draft PR description.**
+
+```bash
+gh pr edit --body "Closes #125 — Collections overhaul: hierarchical tags, sidebar tree, list/grid views, shadcn/ui foundation."
+```
+
+- [ ] **Step 4: Poll CI checks; merge with `gh pr merge --squash --repo toofanian/bummer` after pass + user approval.**
+
+---
+
+## Self-Review Checklist (run before handoff)
+
+- [x] Spec coverage: all sections of `docs/specs/2026-05-04-collections-overhaul-design.md` mapped to a task
+- [x] No "TBD" / "fill in later" placeholders in code blocks
+- [x] Function signatures consistent across tasks (e.g. `addAlbumsToCollection`, `getDescendantIds`)
+- [x] Migration applied before backend tasks merge to main
+- [x] Tests written before implementation in every code task
+- [x] Each task ends in a commit

--- a/docs/specs/2026-05-04-collections-overhaul-design.md
+++ b/docs/specs/2026-05-04-collections-overhaul-design.md
@@ -1,0 +1,208 @@
+# Collections Overhaul — Design Spec
+
+**Date:** 2026-05-04
+**Issue:** [#125](https://github.com/toofanian/bummer/issues/125)
+**Status:** Approved
+
+## Goal
+
+Rebuild the collections experience around hierarchical tags, denser layouts, and a sidebar-driven browsing model. Replace the flat collection list with a tag tree + collection grid/list, while preserving the existing "serving platter" workflow for adding albums.
+
+## Non-Goals
+
+- No auto-generation, recommendations, or AI-driven organization. All organization is user-driven.
+- No changes to library sync, playback, or non-collection UI.
+- No removal of the existing bulk-add flow from Library / Collection detail (Flow B).
+
+## User Decisions Locked In
+
+| Decision | Choice |
+|---|---|
+| Hierarchy model | Tags (data) browsed as folders (UX) |
+| Tags per collection | Many |
+| Tag nesting | Hierarchical (parent → child, arbitrary depth) |
+| Browsing nav | Sidebar tag tree + main pane (mobile: drill-down) |
+| View modes | List **and** grid, user-toggled |
+| Grid card | Album art mosaic + collection name only |
+| Pinned cover art | Overrides mosaic when set (existing behavior) |
+| Tag CRUD | Inline tag-add on collection editor + dedicated tag manager page |
+| Component foundation | shadcn/ui (replaces hand-built primitives where it fits) |
+| Add-to-collection from Collections pane (Flow A) | Preserved — Recently Added / Recently Played rows stay at bottom of main pane |
+| Add-to-collection from Library / Detail (Flow B) | Unchanged |
+
+## Data Model
+
+### New tables
+
+```sql
+-- Tags form a forest per user. parent_tag_id = NULL for root tags.
+create table tags (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references auth.users(id) on delete cascade,
+    name text not null,
+    parent_tag_id uuid references tags(id) on delete cascade,
+    position integer not null default 0,
+    created_at timestamptz not null default now(),
+    unique (user_id, parent_tag_id, name)  -- sibling names unique per parent
+);
+
+create index idx_tags_user_parent on tags(user_id, parent_tag_id, position);
+
+-- Many-to-many: collection ↔ tag
+create table collection_tags (
+    collection_id uuid not null references collections(id) on delete cascade,
+    tag_id uuid not null references tags(id) on delete cascade,
+    created_at timestamptz not null default now(),
+    primary key (collection_id, tag_id)
+);
+
+create index idx_collection_tags_tag on collection_tags(tag_id);
+```
+
+RLS: user can only see/modify their own tags and their own `collection_tags` (enforced via `collections.user_id` and `tags.user_id`).
+
+### Existing `collections` table
+
+Unchanged. Keep `position`, `description`, `cover_album_id`.
+
+## Backend Endpoints
+
+All under `backend/routers/metadata.py` (or new `tags.py` if file grows too large — judgment call during implementation).
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/tags` | List all user's tags as flat array (frontend builds tree) |
+| POST | `/tags` | Create tag `{ name, parent_tag_id? }` — assigns next position among siblings |
+| PATCH | `/tags/{id}` | Rename tag `{ name }` |
+| PUT | `/tags/{id}/move` | Reparent tag `{ parent_tag_id, position }` |
+| DELETE | `/tags/{id}` | Delete tag (cascades to descendants and `collection_tags`) |
+| PUT | `/tags/reorder` | Bulk reorder siblings under a parent `{ parent_tag_id, tag_ids: [...] }` |
+| GET | `/collections/{id}/tags` | List tags on a collection |
+| PUT | `/collections/{id}/tags` | Replace full tag set on a collection `{ tag_ids: [...] }` |
+| GET | `/tags/{id}/collections` | List collections that have this tag (direct membership only — frontend handles hierarchy expansion) |
+
+Existing `/collections` endpoints unchanged.
+
+## Frontend Architecture
+
+### New layout (Collections view)
+
+**Desktop:**
+
+```
+┌────────────────────────────────────────────────────────────┐
+│  Top nav (existing)                                         │
+├──────────────┬─────────────────────────────────────────────┤
+│              │  [List/Grid toggle]    [+ New Collection]    │
+│  Tag Tree    │                                              │
+│  (sidebar)   │  Collection grid or list                     │
+│              │  (filtered by selected tag)                  │
+│  • All       │                                              │
+│  ▾ Genre     │                                              │
+│    • Jazz    │                                              │
+│    • Rock    │                                              │
+│  • Mood      │                                              │
+│  • Favorites │  ─────────────────────────────────────────   │
+│              │  Recently Added                              │
+│  [+ Tag]     │  [album art row — serving platter]           │
+│  [Manage]    │  Recently Played                             │
+│              │  [album art row — serving platter]           │
+└──────────────┴─────────────────────────────────────────────┘
+```
+
+**Mobile:**
+
+- Top level = tag drill-down page (list of root tags + "All collections")
+- Tap tag → page showing child tags + collections in that tag
+- Tap collection → existing collection detail
+- Serving platter rows on the "All collections" page bottom (unchanged)
+- Bottom tab bar unchanged
+
+### New components
+
+| Component | Purpose | Notes |
+|---|---|---|
+| `TagTreeSidebar` | Desktop sidebar tag tree | shadcn `Collapsible` primitives, drag-reorder via dnd-kit |
+| `TagDrillPage` | Mobile drill-down view | Renders one tag's children + collections |
+| `CollectionGrid` | Grid of collection cards | Mosaic art + name |
+| `CollectionList` | Compact list of collections | Replaces current row layout, denser |
+| `CollectionCard` | Single grid card | 2x2 album mosaic, fallback to single pinned cover |
+| `ViewToggle` | List/grid switch | shadcn `ToggleGroup` |
+| `TagManagerPage` | Dedicated CRUD page | Tree editor: add/rename/delete/move/reparent |
+| `TagPickerInput` | Inline tag chip input on collection editor | Autocomplete existing + create new on Enter |
+
+### Components reused unchanged
+
+- `AlbumPromptBar` (serving platter floating action bar)
+- `CollectionPicker` (modal — used by BulkAddBar)
+- `BulkAddBar`
+- `CollectionDetailHeader` (gains a `TagPickerInput`)
+- `AlbumArtStrip`
+
+### Components removed / replaced
+
+- Existing `CollectionsPane` row rendering — replaced by `CollectionGrid` / `CollectionList`. Hooks and prop wiring preserved where possible. The component itself can stay as a thin orchestrator.
+
+### State management
+
+App.jsx today carries 40+ useState calls and scattered `albumCollectionMap` updates. Scope the cleanup tightly to what this overhaul touches:
+
+- Add `tags[]` and `selectedTagId` to App.jsx state.
+- Centralize collection-membership mutations into a small reducer or hook (`useCollectionMembership`) — eliminates the 5+ scattered `setAlbumCollectionMap` patterns. **In scope** because this code is directly affected by the overhaul.
+- Don't touch unrelated App.jsx state (playback, sync, auth) — out of scope.
+
+### Filtering by tag (frontend)
+
+When a tag is selected:
+- Show all collections that have **the selected tag OR any of its descendants**.
+- Tree expansion / descendant lookup is computed client-side from the flat `tags[]` array.
+
+"All" (root) = no filter, show every collection.
+
+## shadcn Adoption
+
+Install only what we need:
+
+- `Collapsible` — tag tree nodes
+- `ToggleGroup` — list/grid view toggle
+- `Card` — collection grid cards
+- `Command` — tag autocomplete in `TagPickerInput`
+- `Badge` — tag chips on collection editor
+- `Tabs` — possibly for tag manager page sections (TBD by implementer)
+- Keep existing dnd-kit for drag/reorder
+
+Theme tokens stay aligned to current Tailwind config (text-dim, etc.). No global redesign — components adopt existing palette.
+
+## Migration & Rollout
+
+- One Supabase migration: creates `tags` and `collection_tags` tables + indexes + RLS.
+- No data backfill needed — users start with zero tags. Existing collections show under "All" until tagged.
+- Apply migration to prod **before** merging the PR (preview shares prod DB).
+- No feature flag — ship the new UI directly. The data model is additive; nothing breaks if frontend isn't shipped yet.
+
+## Testing
+
+- **Backend:** pytest for each new endpoint — happy path + auth isolation + cascade-delete of tags.
+- **Frontend:**
+  - `TagTreeSidebar` — render, expand/collapse, select, reorder
+  - `TagPickerInput` — autocomplete, create-on-Enter, chip add/remove
+  - `CollectionGrid` / `CollectionCard` — mosaic rendering, pinned cover override, click to open
+  - `CollectionList` — denser layout renders, all existing behaviors (rename/delete/reorder) still work
+  - `TagManagerPage` — CRUD flows, hierarchy moves, cascade-delete confirmation
+  - Filter behavior — selecting a tag shows correct collections (including descendants)
+- TDD throughout per project convention.
+
+## Open Questions for Implementation
+
+1. **Drag a collection onto a tag in the sidebar to assign it?** Nice-to-have, not required for v1. Defer.
+2. **Tag color/icon?** Out of scope for v1. Can add later as `tags.color` / `tags.icon` columns.
+3. **Show tag chips on collection cards?** No (user picked card text = name only). Tags visible only in collection detail / tag manager.
+4. **Rename "Collections" view?** No. Keep label.
+
+## Out of Scope
+
+- iOS-style tiled grid with auto-mosaics (issue #98) — partly addressed by `CollectionCard` mosaic but full visual polish deferred.
+- Inline collection picker on row tap (issue #88) — defer; existing modal picker stays.
+- Folder hierarchy as a separate concept (issue #92) — superseded by tag tree.
+- Bulk add bar persistence across pages (issue #122) — separate bug, separate PR.
+- App.jsx cleanup beyond the collection-membership reducer.

--- a/frontend/components.json
+++ b/frontend/components.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "base-nova",
+  "rsc": false,
+  "tsx": false,
+  "tailwind": {
+    "config": "",
+    "css": "src/tailwind.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "iconLibrary": "lucide",
+  "rtl": false,
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "menuColor": "default",
+  "menuAccent": "subtle",
+  "registries": {}
+}

--- a/frontend/jsconfig.json
+++ b/frontend/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,14 +8,23 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@base-ui/react": "^1.4.1",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@fontsource-variable/geist": "^5.2.8",
         "@splidejs/react-splide": "^0.7.12",
         "@splidejs/splide": "^4.1.4",
         "@supabase/supabase-js": "^2.101.1",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
+        "lucide-react": "^1.14.0",
         "react": "^19.2.0",
-        "react-dom": "^19.2.0"
+        "react-dom": "^19.2.0",
+        "shadcn": "^4.6.0",
+        "tailwind-merge": "^3.5.0",
+        "tw-animate-css": "^1.4.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -113,7 +122,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -128,7 +136,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
       "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -138,7 +145,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -169,7 +175,6 @@
       "version": "7.29.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
       "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -182,11 +187,22 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
@@ -199,12 +215,45 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.3.tgz",
+      "integrity": "sha512-RpLYy2sb51oNLjuu1iD3bwBqCBWUzjO0ocp+iaCP/lJtb2CPLcnC2Fftw+4sAzaMELGeWTgExSKADbdo0GFVzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/traverse": "^7.29.0",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
+      "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.5",
+        "@babel/types": "^7.28.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -213,7 +262,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
       "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.6",
@@ -227,7 +275,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
@@ -241,12 +288,53 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
       "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
-      "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
+      "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -255,7 +343,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -265,7 +352,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -275,7 +361,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -285,7 +370,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
       "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
@@ -299,7 +383,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
       "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -309,6 +392,52 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
+      "integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
@@ -343,11 +472,48 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/runtime": {
+    "node_modules/@babel/plugin-transform-typescript": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.6.tgz",
+      "integrity": "sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz",
+      "integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -357,7 +523,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
@@ -372,7 +537,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
       "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -391,7 +555,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -399,6 +562,66 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@base-ui/react": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.4.1.tgz",
+      "integrity": "sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@base-ui/utils": "0.2.8",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@date-fns/tz": "^1.2.0",
+        "@types/react": "^17 || ^18 || ^19",
+        "date-fns": "^4.0.0",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@date-fns/tz": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@base-ui/utils": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.8.tgz",
+      "integrity": "sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@floating-ui/utils": "^0.2.11",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@bramus/specificity": {
@@ -597,6 +820,175 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dotenvx/dotenvx": {
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.64.0.tgz",
+      "integrity": "sha512-6+xRpZaWuHXEqnhBjae+VmQI9Uaqw5Uzu/ScpO+W7ww9Zp3lHSNBoNjFcUxhrCyc7pRGQzyDjhKzloqrPHERiQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "commander": "^11.1.0",
+        "dotenv": "^17.2.1",
+        "eciesjs": "^0.4.10",
+        "execa": "^5.1.1",
+        "fdir": "^6.2.0",
+        "ignore": "^5.3.0",
+        "object-treeify": "1.1.33",
+        "picomatch": "^4.0.4",
+        "which": "^4.0.0",
+        "yocto-spinner": "^1.1.0"
+      },
+      "bin": {
+        "dotenvx": "src/cli/dotenvx.js"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@dotenvx/dotenvx/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@dotenvx/dotenvx/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@dotenvx/dotenvx/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@dotenvx/dotenvx/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/@dotenvx/dotenvx/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@dotenvx/dotenvx/node_modules/isexe": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@dotenvx/dotenvx/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@dotenvx/dotenvx/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@dotenvx/dotenvx/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/@dotenvx/dotenvx/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@dotenvx/dotenvx/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@ecies/ciphers": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.6.tgz",
+      "integrity": "sha512-patgsRPKGkhhoBjETV4XxD0En4ui5fbX0hzayqI3M8tvNMGUoUvmyYAIWwlxBc1KX5cturfqByYdj5bYGRpN9g==",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1",
+        "deno": ">=2.7.10",
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@noble/ciphers": "^1.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1216,6 +1608,65 @@
         }
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@fontsource-variable/geist": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/geist/-/geist-5.2.8.tgz",
+      "integrity": "sha512-cJ6m9e+8MQ5dCYJsLylfZrgBh6KkG4bOLckB35Tr9J/EqdkEM6QllH5PxqP1dhTvFup+HtMRPuz9xOjxXJggxw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1268,11 +1719,92 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
+      "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.12.tgz",
+      "integrity": "sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.9",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.1.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.9.tgz",
+      "integrity": "sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
+      "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
+      "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1283,7 +1815,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -1294,7 +1825,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1304,19 +1834,198 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.8",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.8.tgz",
+      "integrity": "sha512-pRLMNKTSGRoLq+KnEB/7OY5vijw1XmcheAAOiv6pj7W1FG32kAGqj1C/RK/cqxRGr1Fh+zBi8sDur8kj3EQv6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mswjs/interceptors/node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "license": "MIT"
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz",
+      "integrity": "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==",
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "license": "MIT"
     },
     "node_modules/@playwright/test": {
       "version": "1.58.2",
@@ -1332,6 +2041,447 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1690,6 +2840,24 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@splidejs/react-splide": {
       "version": "0.7.12",
@@ -2161,6 +3329,53 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@ts-morph/common": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.27.0.tgz",
+      "integrity": "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "^3.3.3",
+        "minimatch": "^10.0.1",
+        "path-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -2259,7 +3474,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2269,11 +3484,32 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
+      "integrity": "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/validate-npm-package-name": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.2.tgz",
+      "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -2416,6 +3652,19 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2443,7 +3692,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -2466,13 +3714,50 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2481,7 +3766,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2497,8 +3781,19 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -2520,6 +3815,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
+      "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2531,7 +3838,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
       "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -2550,6 +3856,30 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -2561,11 +3891,22 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2595,11 +3936,63 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2609,7 +4002,6 @@
       "version": "1.0.30001774",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
       "integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2653,11 +4045,135 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/code-block-writer": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
+      "license": "MIT"
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2670,8 +4186,16 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2680,18 +4204,99 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2723,6 +4328,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/cssstyle": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.1.0.tgz",
@@ -2753,8 +4370,17 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -2774,7 +4400,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2795,12 +4420,84 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -2822,6 +4519,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -2830,12 +4542,75 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eciesjs": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.18.tgz",
+      "integrity": "sha512-wG99Zcfcys9fZux7Cft8BAX/YrOJLJSZ3jyYPfhZHqN2E+Ffx+QXBDsv3gubEgPtV6dTzJMSQUwk1H98/t/0wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ecies/ciphers": "^0.2.5",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "^1.9.7",
+        "@noble/hashes": "^1.8.0"
+      },
+      "engines": {
+        "bun": ">=1",
+        "deno": ">=2",
+        "node": ">=16"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
       "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.20.0",
@@ -2864,12 +4639,60 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -2917,11 +4740,16 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -3074,6 +4902,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -3130,6 +4971,62 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -3140,12 +5037,100 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.0.tgz",
+      "integrity": "sha512-XKhFohWaSBdVJNTi5TaHziqnPkv04I9UQV6q1Wy7Ui6GGQZVW12ojDFwqer14EvCXxjvPG0CyWXx7cAXpALB4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -3161,11 +5146,59 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.1.tgz",
+      "integrity": "sha512-h2r7rcm6Ee/J8o0LD5djLuFVcfbZxhvho4vvsbeV0aMvXjUgqv4YpxpkEx0d68l6+IleVfLAdVEfhR7QNMkGHQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -3179,6 +5212,44 @@
         }
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3190,6 +5261,39 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -3230,6 +5334,50 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3245,14 +5393,123 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuzzysort": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-3.1.0.tgz",
+      "integrity": "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==",
+      "license": "MIT"
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/get-own-enumerable-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-keys/-/get-own-enumerable-keys-1.0.0.tgz",
+      "integrity": "sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/glob-parent": {
@@ -3281,12 +5538,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/graphql": {
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
+      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -3296,6 +5573,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
+      "integrity": "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.10",
+        "set-cookie-parser": "^3.0.1"
       }
     },
     "node_modules/hermes-estree": {
@@ -3315,6 +5626,15 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -3326,6 +5646,26 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -3346,7 +5686,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -3354,6 +5693,15 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
       }
     },
     "node_modules/iceberg-js": {
@@ -3365,11 +5713,26 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -3379,7 +5742,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -3412,27 +5774,160 @@
         "node": ">=8"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-3.0.0.tgz",
+      "integrity": "sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -3442,11 +5937,67 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-regexp": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
+      "integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jiti": {
@@ -3459,18 +6010,25 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3524,7 +6082,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -3540,12 +6097,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -3558,13 +6127,24 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/keyv": {
@@ -3575,6 +6155,15 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/levn": {
@@ -3852,6 +6441,12 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -3875,14 +6470,62 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.14.0.tgz",
+      "integrity": "sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {
@@ -3906,12 +6549,128 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
       "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
@@ -3936,18 +6695,91 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/msw": {
+      "version": "2.14.3",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.14.3.tgz",
+      "integrity": "sha512-kk8G5cocVlJ4wsKMGZegn2H6XLOEKjbA+nSJE2354e/SRp4mDicCHUYnMXpymzVcVDCs+GUAsmNqSn+yHv4T2A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/confirm": "^6.0.11",
+        "@mswjs/interceptors": "^0.41.3",
+        "@open-draft/deferred-promise": "^3.0.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.1.1",
+        "graphql": "^16.13.2",
+        "headers-polyfill": "^5.0.1",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.11.11",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.1",
+        "type-fest": "^5.5.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3969,12 +6801,116 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-treeify": {
+      "version": "1.1.33",
+      "resolved": "https://registry.npmjs.org/object-treeify/-/object-treeify-1.1.33.tgz",
+      "integrity": "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -3986,6 +6922,62 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -4004,6 +6996,47 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -4041,13 +7074,42 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parse5": {
@@ -4063,6 +7125,21 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4077,11 +7154,16 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -4094,20 +7176,27 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/playwright": {
@@ -4161,7 +7250,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4184,6 +7272,31 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/prelude-ls": {
@@ -4226,6 +7339,56 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prompts/node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4234,6 +7397,65 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/react": {
@@ -4275,6 +7497,91 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/recast": {
+      "version": "0.23.11",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
+      "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.16.1",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tiny-invariant": "^1.3.3",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -4289,24 +7596,69 @@
         "node": ">=8"
       }
     },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rettime": {
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.11.tgz",
+      "integrity": "sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==",
+      "license": "MIT"
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rollup": {
@@ -4354,6 +7706,73 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -4377,17 +7796,126 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shadcn": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/shadcn/-/shadcn-4.6.0.tgz",
+      "integrity": "sha512-4XeMwFf8ZZxmqQQp+U+Nsq2M+cY4Da8Joo/EaMdHVc4uVuWSTJoeidlZ3gDjyxXCjYB1FLcxYwR4lYQAH8emOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/parser": "^7.28.0",
+        "@babel/plugin-transform-typescript": "^7.28.0",
+        "@babel/preset-typescript": "^7.27.1",
+        "@dotenvx/dotenvx": "^1.48.4",
+        "@modelcontextprotocol/sdk": "^1.26.0",
+        "@types/validate-npm-package-name": "^4.0.2",
+        "browserslist": "^4.26.2",
+        "commander": "^14.0.0",
+        "cosmiconfig": "^9.0.0",
+        "dedent": "^1.6.0",
+        "deepmerge": "^4.3.1",
+        "diff": "^8.0.2",
+        "execa": "^9.6.0",
+        "fast-glob": "^3.3.3",
+        "fs-extra": "^11.3.1",
+        "fuzzysort": "^3.1.0",
+        "https-proxy-agent": "^7.0.6",
+        "kleur": "^4.1.5",
+        "msw": "^2.10.4",
+        "node-fetch": "^3.3.2",
+        "open": "^11.0.0",
+        "ora": "^8.2.0",
+        "postcss": "^8.5.6",
+        "postcss-selector-parser": "^7.1.0",
+        "prompts": "^2.4.2",
+        "recast": "^0.23.11",
+        "stringify-object": "^5.0.0",
+        "tailwind-merge": "^3.0.1",
+        "ts-morph": "^26.0.0",
+        "tsconfig-paths": "^4.2.0",
+        "validate-npm-package-name": "^7.0.1",
+        "zod": "^3.24.1",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "bin": {
+        "shadcn": "dist/index.js"
+      }
+    },
+    "node_modules/shadcn/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -4400,10 +7928,81 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -4413,11 +8012,37 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4430,12 +8055,121 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stringify-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-5.0.0.tgz",
+      "integrity": "sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "get-own-enumerable-keys": "^1.0.0",
+        "is-obj": "^3.0.0",
+        "is-regexp": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/yeoman/stringify-object?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -4483,6 +8217,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
@@ -4503,6 +8259,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -4552,7 +8314,6 @@
       "version": "7.0.23",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.23.tgz",
       "integrity": "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^7.0.23"
@@ -4565,14 +8326,33 @@
       "version": "7.0.23",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
       "integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
-      "dev": true,
       "license": "MIT"
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tough-cookie": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
-      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
-      "dev": true,
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -4594,11 +8374,44 @@
         "node": ">=20"
       }
     },
+    "node_modules/ts-morph": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-26.0.0.tgz",
+      "integrity": "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.27.0",
+        "code-block-writer": "^13.0.3"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tw-animate-css": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
+      "integrity": "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Wombosvideo"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4611,6 +8424,35 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/undici": {
@@ -4629,11 +8471,49 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4668,6 +8548,82 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/validate-npm-package-name": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+      "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vite": {
@@ -4836,6 +8792,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -4875,7 +8840,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -4914,6 +8878,61 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
@@ -4935,6 +8954,22 @@
         }
       }
     },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -4952,12 +8987,79 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -4972,14 +9074,49 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/yocto-spinner": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-1.2.0.tgz",
+      "integrity": "sha512-Yw0hUB6UA3o4YUgKy3oSe9a4cxoaZ9sBfYDw+JSxo6Id0KoJGoxzPA24qqUXYKBWABs/zDSGTz9kww7t3F0XGw==",
+      "license": "MIT",
+      "dependencies": {
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.19"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/zod": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zod-validation-error": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,14 +12,23 @@
     "test:e2e": "playwright test --config e2e/playwright.config.js"
   },
   "dependencies": {
+    "@base-ui/react": "^1.4.1",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@fontsource-variable/geist": "^5.2.8",
     "@splidejs/react-splide": "^0.7.12",
     "@splidejs/splide": "^4.1.4",
     "@supabase/supabase-js": "^2.101.1",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
+    "lucide-react": "^1.14.0",
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "shadcn": "^4.6.0",
+    "tailwind-merge": "^3.5.0",
+    "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1051,15 +1051,6 @@ export default function App() {
                 }}
                 onCreateCollection={handleCreateCollection}
                 onReorder={handleReorderCollections}
-                showCreate={showCollectionCreate}
-                onShowCreateChange={setShowCollectionCreate}
-                createName={collectionCreateName}
-                onCreateNameChange={setCollectionCreateName}
-                onCreateSubmit={(name) => {
-                  handleCreateCollection(name)
-                  setCollectionCreateName('')
-                  setShowCollectionCreate(false)
-                }}
                 tags={tags}
                 selectedTagId={selectedTagId}
                 onSelectTag={setSelectedTagId}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -28,6 +28,7 @@ import LibraryViewToggle from './components/LibraryViewToggle'
 import { useIsMobile } from './hooks/useIsMobile'
 import { useAuth } from './hooks/useAuth'
 import { useSpotifyAuth } from './hooks/useSpotifyAuth'
+import { useCollectionMembership } from './hooks/useCollectionMembership'
 import SignupScreen from './components/SignupScreen'
 import OnboardingWizard from './components/OnboardingWizard'
 import BulkAddBar from './components/BulkAddBar'
@@ -45,7 +46,13 @@ export default function App() {
   const [collectionAlbums, setCollectionAlbums] = useState([])
   const [listenCounts, setListenCounts] = useState({})
   // albumCollectionMap: { [service_id]: string[] } — IDs of collections the album belongs to
-  const [albumCollectionMap, setAlbumCollectionMap] = useState({})
+  const {
+    albumCollectionMap,
+    setAlbumCollectionMap,
+    addAlbumsToCollection,
+    removeAlbumFromCollection,
+    deleteCollection: removeCollectionFromMap,
+  } = useCollectionMembership({})
   const [albumsLoading, setAlbumsLoading] = useState(true)
   const [collectionsLoading, setCollectionsLoading] = useState(true)
   const [syncing, setSyncing] = useState(false)
@@ -357,13 +364,7 @@ export default function App() {
     })
 
     const prevAlbumCollectionMap = albumCollectionMap
-    setAlbumCollectionMap(prev => {
-      const next = {}
-      for (const [albumId, colIds] of Object.entries(prev)) {
-        next[albumId] = colIds.filter(cid => cid !== id)
-      }
-      return next
-    })
+    removeCollectionFromMap(id)
 
     try {
       const res = await apiFetch(`/collections/${id}`, { method: 'DELETE' }, sessionRef.current)
@@ -382,16 +383,7 @@ export default function App() {
     const data = await res.json()
     // Update albumCollectionMap with this collection's membership
     if (data.albums) {
-      setAlbumCollectionMap(prev => {
-        const next = { ...prev }
-        data.albums.forEach(album => {
-          if (!next[album.service_id]) next[album.service_id] = []
-          if (!next[album.service_id].includes(collectionId)) {
-            next[album.service_id] = [...next[album.service_id], collectionId]
-          }
-        })
-        return next
-      })
+      addAlbumsToCollection(collectionId, data.albums.map(a => a.service_id))
     }
     return data.albums
   }
@@ -400,6 +392,9 @@ export default function App() {
     const res = await apiFetch(`/collections/${collection.id}/albums`, {}, sessionRef.current)
     const data = await res.json()
     setCollectionAlbums(data.albums)
+    if (data.albums) {
+      addAlbumsToCollection(collection.id, data.albums.map(a => a.service_id))
+    }
     setView(collection)
   }
 
@@ -572,19 +567,12 @@ export default function App() {
         method: 'POST',
         body: JSON.stringify({ service_id: albumId }),
       }, sessionRef.current)
-      setAlbumCollectionMap(prev => {
-        const existing = prev[albumId] || []
-        if (existing.includes(collectionId)) return prev
-        return { ...prev, [albumId]: [...existing, collectionId] }
-      })
+      addAlbumsToCollection(collectionId, [albumId])
     } else {
       await apiFetch(`/collections/${collectionId}/albums/${albumId}`, { method: 'DELETE' }, sessionRef.current)
-      setAlbumCollectionMap(prev => ({
-        ...prev,
-        [albumId]: (prev[albumId] || []).filter(id => id !== collectionId),
-      }))
+      removeAlbumFromCollection(collectionId, albumId)
     }
-  }, [])
+  }, [addAlbumsToCollection, removeAlbumFromCollection])
 
   async function handleReorderCollectionAlbums(albumIds) {
     // Optimistic reorder: rearrange collectionAlbums to match the new order
@@ -658,16 +646,7 @@ export default function App() {
       if (!res.ok) throw new Error('Failed to bulk add albums')
       const data = await res.json()
       // Update albumCollectionMap
-      setAlbumCollectionMap(prev => {
-        const next = { ...prev }
-        ids.forEach(id => {
-          if (!next[id]) next[id] = []
-          if (!next[id].includes(collectionId)) {
-            next[id] = [...next[id], collectionId]
-          }
-        })
-        return next
-      })
+      addAlbumsToCollection(collectionId, ids)
       // Use server-reported count if available, otherwise re-count
       if (data.album_count != null) {
         setCollections(prev => prev.map(c =>
@@ -929,16 +908,7 @@ export default function App() {
                   }, sessionRef.current)
                   if (!res.ok) throw new Error('Failed to bulk add')
                   const data = await res.json()
-                  setAlbumCollectionMap(prev => {
-                    const next = { ...prev }
-                    albumIds.forEach(id => {
-                      if (!next[id]) next[id] = []
-                      if (!next[id].includes(collectionId)) {
-                        next[id] = [...next[id], collectionId]
-                      }
-                    })
-                    return next
-                  })
+                  addAlbumsToCollection(collectionId, albumIds)
                   if (data.album_count != null) {
                     setCollections(prev => prev.map(c =>
                       c.id === collectionId ? { ...c, album_count: data.album_count } : c
@@ -1285,16 +1255,7 @@ export default function App() {
                 }, sessionRef.current)
                 if (!res.ok) throw new Error('Failed to bulk add')
                 const data = await res.json()
-                setAlbumCollectionMap(prev => {
-                  const next = { ...prev }
-                  albumIds.forEach(id => {
-                    if (!next[id]) next[id] = []
-                    if (!next[id].includes(collectionId)) {
-                      next[id] = [...next[id], collectionId]
-                    }
-                  })
-                  return next
-                })
+                addAlbumsToCollection(collectionId, albumIds)
                 if (data.album_count != null) {
                   setCollections(prev => prev.map(c =>
                     c.id === collectionId ? { ...c, album_count: data.album_count } : c

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,7 @@ function flattenArtists(albums) {
 import AlbumTable from './components/AlbumTable'
 import CollectionsPane from './components/CollectionsPane'
 import CollectionDetailHeader from './components/CollectionDetailHeader'
+import TagManagerPage from './components/TagManagerPage'
 import PlaybackBar from './components/PlaybackBar'
 import NowPlayingPane from './components/NowPlayingPane'
 import DigestView from './components/DigestView'
@@ -125,7 +126,7 @@ export default function App() {
   const [playbackOrigin, setPlaybackOrigin] = useState(null)
   const viewRef = useRef(view)
   viewRef.current = view
-  const isInCollection = view !== 'home' && view !== 'library' && view !== 'collections' && view !== 'digest' && view !== 'settings'
+  const isInCollection = view !== 'home' && view !== 'library' && view !== 'collections' && view !== 'digest' && view !== 'settings' && view !== 'tag-manager'
   const artistCount = useMemo(() => {
     const artists = new Set()
     for (const album of albums) {
@@ -666,6 +667,95 @@ export default function App() {
     ))
   }
 
+  // Re-fetch the tag tree from the backend. Used after any tag mutation so the
+   // sidebar / tag manager / picker all reflect the new state.
+  const refreshTags = useCallback(async () => {
+    try {
+      const tagsRaw = await apiFetch('/tags', {}, sessionRef.current).then(r => r.json())
+      setTags(Array.isArray(tagsRaw) ? tagsRaw : [])
+    } catch {
+      // non-fatal — leave existing tag state
+    }
+  }, [])
+
+  // Re-fetch the collection<->tag membership map. Used after a tag delete (which
+   // cascades into collection_tags) and after a collection's tag-set is edited.
+  const refreshCollectionTagsMap = useCallback(async () => {
+    try {
+      const { data, error } = await supabase
+        .from('collection_tags')
+        .select('collection_id, tag_id')
+      if (error) return
+      const map = {}
+      for (const row of data || []) {
+        if (!map[row.collection_id]) map[row.collection_id] = []
+        map[row.collection_id].push(row.tag_id)
+      }
+      setCollectionTagsMap(map)
+    } catch {
+      // non-fatal
+    }
+  }, [])
+
+  async function handleCreateTag({ name, parent_tag_id }) {
+    const res = await apiFetch('/tags', {
+      method: 'POST',
+      body: JSON.stringify({ name, parent_tag_id: parent_tag_id ?? null }),
+    }, sessionRef.current)
+    if (!res.ok) return null
+    const created = await res.json()
+    await refreshTags()
+    return created
+  }
+
+  async function handleRenameTag(tagId, name) {
+    await apiFetch(`/tags/${tagId}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ name }),
+    }, sessionRef.current)
+    await refreshTags()
+  }
+
+  async function handleDeleteTag(tagId) {
+    await apiFetch(`/tags/${tagId}`, { method: 'DELETE' }, sessionRef.current)
+    // Children cascade-delete on the server, which can free collection_tag rows.
+    await Promise.all([refreshTags(), refreshCollectionTagsMap()])
+    if (selectedTagId === tagId) setSelectedTagId(null)
+  }
+
+  async function handleMoveTag(tagId, { parent_tag_id, position }) {
+    await apiFetch(`/tags/${tagId}/move`, {
+      method: 'PUT',
+      body: JSON.stringify({ parent_tag_id: parent_tag_id ?? null, position }),
+    }, sessionRef.current)
+    await refreshTags()
+  }
+
+  async function handleReorderTags(parent_tag_id, tagIds) {
+    await apiFetch('/tags/reorder', {
+      method: 'PUT',
+      body: JSON.stringify({ parent_tag_id: parent_tag_id ?? null, tag_ids: tagIds }),
+    }, sessionRef.current)
+    await refreshTags()
+  }
+
+  // Used by TagPickerInput on a collection: PUT the new full tag id list,
+  // then update collectionTagsMap so the sidebar filter reflects the change
+  // immediately without a full re-fetch.
+  async function handleSetCollectionTags(collectionId, nextIds) {
+    await apiFetch(`/collections/${collectionId}/tags`, {
+      method: 'PUT',
+      body: JSON.stringify({ tag_ids: nextIds }),
+    }, sessionRef.current)
+    setCollectionTagsMap(prev => ({ ...prev, [collectionId]: nextIds }))
+  }
+
+  // Picker's onCreate: create a root-level tag, refresh, and return the created
+  // tag so the picker can append its id to selectedTagIds.
+  async function handleCreateTagFromPicker(name) {
+    return handleCreateTag({ name, parent_tag_id: null })
+  }
+
   function handleToggleSelect(albumId) {
     setSelectedAlbumIds(prev =>
       prev.includes(albumId) ? prev.filter(id => id !== albumId) : [...prev, albumId]
@@ -989,6 +1079,20 @@ export default function App() {
             </div>
           )}
 
+          {view === 'tag-manager' && (
+            <div className="flex-1 overflow-hidden">
+              <TagManagerPage
+                tags={tags}
+                onCreate={handleCreateTag}
+                onRename={handleRenameTag}
+                onDelete={handleDeleteTag}
+                onMove={handleMoveTag}
+                onReorder={handleReorderTags}
+                onClose={() => setView('collections')}
+              />
+            </div>
+          )}
+
           {isInCollection && (
             <div className="flex flex-col flex-1 overflow-hidden">
               <CollectionDetailHeader
@@ -999,6 +1103,10 @@ export default function App() {
                 onDescriptionChange={(desc) => handleUpdateCollectionDescription(view.id, desc)}
                 onRename={(newName) => handleRenameCollection(view.id, newName)}
                 onPlay={handlePlayCollection}
+                allTags={tags}
+                selectedTagIds={collectionTagsMap[view.id] ?? []}
+                onTagsChange={(nextIds) => handleSetCollectionTags(view.id, nextIds)}
+                onCreateTag={handleCreateTagFromPicker}
               />
               <div className="flex-1 overflow-y-auto">
                 <AlbumTable
@@ -1335,6 +1443,20 @@ export default function App() {
           </div>
         )}
 
+        {view === 'tag-manager' && (
+          <div className="flex-1 overflow-hidden">
+            <TagManagerPage
+              tags={tags}
+              onCreate={handleCreateTag}
+              onRename={handleRenameTag}
+              onDelete={handleDeleteTag}
+              onMove={handleMoveTag}
+              onReorder={handleReorderTags}
+              onClose={() => setView('collections')}
+            />
+          </div>
+        )}
+
         {isInCollection && (
           <div className="flex flex-col flex-1 overflow-hidden">
             <CollectionDetailHeader
@@ -1345,6 +1467,10 @@ export default function App() {
               onDescriptionChange={(desc) => handleUpdateCollectionDescription(view.id, desc)}
               onRename={(newName) => handleRenameCollection(view.id, newName)}
               onPlay={handlePlayCollection}
+              allTags={tags}
+              selectedTagIds={collectionTagsMap[view.id] ?? []}
+              onTagsChange={(nextIds) => handleSetCollectionTags(view.id, nextIds)}
+              onCreateTag={handleCreateTagFromPicker}
             />
             <div className="flex-1 overflow-y-auto pb-20">
               <AlbumTable

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -37,6 +37,8 @@ import CollectionPicker from './components/CollectionPicker'
 import SettingsPage from './components/SettingsPage'
 import TabBar from './components/TabBar'
 import { apiFetch } from './api'
+import supabase from './supabaseClient'
+import { useCollectionsViewMode } from './hooks/useCollectionsViewMode'
 const CACHE_KEY = 'bsi_albums_cache'
 
 export default function App() {
@@ -44,6 +46,15 @@ export default function App() {
   const [albums, setAlbums] = useState([])
   const [collections, setCollections] = useState([])
   const [collectionAlbums, setCollectionAlbums] = useState([])
+  // Tag tree for the collections sidebar (Task 12 wire-up).
+  const [tags, setTags] = useState([])
+  // Currently-selected tag id in the sidebar (null = "All").
+  const [selectedTagId, setSelectedTagId] = useState(null)
+  // Map of collectionId -> tagId[] used to filter the collections grid by tag.
+  // KNOWN SHORTCUT: populated via direct supabase query rather than a backend
+  // endpoint (see comment in loadData) to avoid an N+1 fetch and a new route.
+  const [collectionTagsMap, setCollectionTagsMap] = useState({})
+  const [viewMode, setViewMode] = useCollectionsViewMode()
   const [listenCounts, setListenCounts] = useState({})
   // albumCollectionMap: { [service_id]: string[] } — IDs of collections the album belongs to
   const {
@@ -164,6 +175,39 @@ export default function App() {
       setAlbumsLoading(true)
     }
 
+    // Fetch tags in parallel with collections (non-fatal: a failure leaves the
+    // sidebar empty rather than breaking the page).
+    const tagsPromise = (async () => {
+      try {
+        const tagsRaw = await apiFetch('/tags', {}, sessionRef.current).then(r => r.json())
+        setTags(Array.isArray(tagsRaw) ? tagsRaw : [])
+      } catch {
+        // swallow — sidebar will just show "No tags yet"
+      }
+    })()
+
+    // Fetch the full collection<->tag membership map directly via supabase.
+    // KNOWN SHORTCUT: avoids adding a new backend endpoint or N+1 calls to
+    // `/collections/{id}/tags`. The supabase client is already authed and RLS
+    // scopes rows to the current user. Revisit if we add a server-side
+    // `GET /collection-tags` endpoint.
+    const collectionTagsPromise = (async () => {
+      try {
+        const { data, error } = await supabase
+          .from('collection_tags')
+          .select('collection_id, tag_id')
+        if (error) return
+        const map = {}
+        for (const row of data || []) {
+          if (!map[row.collection_id]) map[row.collection_id] = []
+          map[row.collection_id].push(row.tag_id)
+        }
+        setCollectionTagsMap(map)
+      } catch {
+        // non-fatal
+      }
+    })()
+
     // Start collections fetch immediately (parallel with sync)
     const collectionsPromise = (async () => {
       try {
@@ -257,8 +301,8 @@ export default function App() {
       }
       setSyncing(false)
 
-      // Await collections (already started in parallel)
-      await collectionsPromise
+      // Await collections + tags + memberships (already started in parallel)
+      await Promise.all([collectionsPromise, tagsPromise, collectionTagsPromise])
     } catch (err) {
       // If we had cached data, keep it visible and swallow the error — a
       // failed background sync shouldn't wipe a warm UI. On cold start the
@@ -926,6 +970,14 @@ export default function App() {
                   setCollectionCreateName('')
                   setShowCollectionCreate(false)
                 }}
+                tags={tags}
+                selectedTagId={selectedTagId}
+                onSelectTag={setSelectedTagId}
+                viewMode={viewMode}
+                onViewModeChange={setViewMode}
+                onManageTags={handleEnterCollection}
+                onOpenTagManager={() => setView('tag-manager')}
+                collectionTagsMap={collectionTagsMap}
               />
               )}
             </div>
@@ -1264,6 +1316,14 @@ export default function App() {
               }}
               onCreateCollection={handleCreateCollection}
               onReorder={handleReorderCollections}
+              tags={tags}
+              selectedTagId={selectedTagId}
+              onSelectTag={setSelectedTagId}
+              viewMode={viewMode}
+              onViewModeChange={setViewMode}
+              onManageTags={handleEnterCollection}
+              onOpenTagManager={() => setView('tag-manager')}
+              collectionTagsMap={collectionTagsMap}
             />
             )}
           </div>

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1866,3 +1866,45 @@ describe('App — create collection from nav bar', () => {
     clearLocalStorageCache()
   })
 })
+
+describe('App — tag manager routing', () => {
+  it('clicking "Manage tags" in the sidebar opens the TagManagerPage view', async () => {
+    seedLocalStorageCache()
+    const TAGS = [
+      { id: 'tag-1', name: 'mood', parent_tag_id: null, position: 0 },
+    ]
+    global.fetch = vi.fn().mockImplementation((url, options) => {
+      if (url.includes('/library/sync-complete') && options?.method === 'POST') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) })
+      }
+      if (url.includes('/library/sync') && !url.includes('/sync-complete') && options?.method === 'POST') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(SYNC_DONE) })
+      }
+      if (url.includes('/library/albums') && !url.includes('/tracks')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(LIBRARY_OK) })
+      }
+      if (url.endsWith('/tags')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(TAGS) })
+      }
+      if (url.includes('/collections')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(COLLECTIONS_OK) })
+      }
+      if (url.includes('/home')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(HOME_OK) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+
+    render(<App />)
+
+    await userEvent.click(await screen.findByRole('button', { name: /collections/i }))
+
+    const manage = await screen.findByRole('button', { name: /manage tags/i })
+    await userEvent.click(manage)
+
+    // TagManagerPage renders a "Tag Manager" heading
+    expect(await screen.findByRole('heading', { name: /tag manager/i })).toBeInTheDocument()
+
+    clearLocalStorageCache()
+  })
+})

--- a/frontend/src/components/CollectionCard.jsx
+++ b/frontend/src/components/CollectionCard.jsx
@@ -1,0 +1,76 @@
+export default function CollectionCard({ collection, albums, onOpen }) {
+  const coverAlbum = collection.cover_album_id
+    ? albums.find(a => a.service_id === collection.cover_album_id)
+    : null
+
+  const mosaicAlbums = albums.slice(0, 4)
+  const isEmpty = albums.length === 0
+  const showCover = !!coverAlbum
+
+  return (
+    <button
+      type="button"
+      data-testid="collection-card"
+      onClick={() => onOpen(collection)}
+      className="group flex flex-col text-left bg-bg-elevated border border-border rounded-md overflow-hidden cursor-pointer p-0 hover:bg-hover transition-colors duration-150"
+    >
+      <div className="aspect-square w-full bg-surface-2 relative">
+        {isEmpty ? (
+          <div
+            data-testid="collection-card-placeholder"
+            className="w-full h-full bg-surface-2"
+            aria-hidden="true"
+          />
+        ) : showCover ? (
+          coverAlbum.image_url ? (
+            <img
+              src={coverAlbum.image_url}
+              alt={coverAlbum.name}
+              className="w-full h-full object-cover"
+            />
+          ) : (
+            <div
+              data-testid="collection-card-placeholder"
+              className="w-full h-full bg-surface-2"
+              aria-hidden="true"
+            />
+          )
+        ) : (
+          <div className="grid grid-cols-2 grid-rows-2 w-full h-full">
+            {Array.from({ length: 4 }).map((_, i) => {
+              const album = mosaicAlbums[i]
+              if (!album) {
+                return (
+                  <div
+                    key={i}
+                    className="bg-surface-2"
+                    aria-hidden="true"
+                  />
+                )
+              }
+              return album.image_url ? (
+                <img
+                  key={album.service_id}
+                  src={album.image_url}
+                  alt={album.name}
+                  className="w-full h-full object-cover"
+                />
+              ) : (
+                <div
+                  key={album.service_id}
+                  className="bg-surface-2"
+                  aria-hidden="true"
+                />
+              )
+            })}
+          </div>
+        )}
+      </div>
+      <div className="px-2 py-2">
+        <div className="text-sm font-medium text-text group-hover:text-text-hover truncate">
+          {collection.name}
+        </div>
+      </div>
+    </button>
+  )
+}

--- a/frontend/src/components/CollectionCard.test.jsx
+++ b/frontend/src/components/CollectionCard.test.jsx
@@ -1,0 +1,57 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import CollectionCard from './CollectionCard'
+
+const ALBUMS = [
+  { service_id: 'a1', name: 'Album One', image_url: 'http://img/1.jpg' },
+  { service_id: 'a2', name: 'Album Two', image_url: 'http://img/2.jpg' },
+  { service_id: 'a3', name: 'Album Three', image_url: 'http://img/3.jpg' },
+  { service_id: 'a4', name: 'Album Four', image_url: 'http://img/4.jpg' },
+  { service_id: 'a5', name: 'Album Five', image_url: 'http://img/5.jpg' },
+]
+
+const COLLECTION = { id: 'c1', name: 'My Collection', cover_album_id: null }
+
+describe('CollectionCard', () => {
+  it('renders 2x2 mosaic from first 4 albums', () => {
+    render(<CollectionCard collection={COLLECTION} albums={ALBUMS} onOpen={() => {}} />)
+    const images = screen.getAllByRole('img')
+    expect(images).toHaveLength(4)
+    expect(images[0]).toHaveAttribute('src', 'http://img/1.jpg')
+    expect(images[3]).toHaveAttribute('src', 'http://img/4.jpg')
+  })
+
+  it('renders single full-bleed cover when cover_album_id matches an album', () => {
+    const collection = { ...COLLECTION, cover_album_id: 'a3' }
+    render(<CollectionCard collection={collection} albums={ALBUMS} onOpen={() => {}} />)
+    const images = screen.getAllByRole('img')
+    expect(images).toHaveLength(1)
+    expect(images[0]).toHaveAttribute('src', 'http://img/3.jpg')
+  })
+
+  it('falls back to mosaic if cover_album_id does not match any album', () => {
+    const collection = { ...COLLECTION, cover_album_id: 'missing' }
+    render(<CollectionCard collection={collection} albums={ALBUMS} onOpen={() => {}} />)
+    const images = screen.getAllByRole('img')
+    expect(images).toHaveLength(4)
+  })
+
+  it('renders gray placeholder when albums empty', () => {
+    const { container } = render(<CollectionCard collection={COLLECTION} albums={[]} onOpen={() => {}} />)
+    expect(container.querySelectorAll('img')).toHaveLength(0)
+    const placeholder = container.querySelector('[data-testid="collection-card-placeholder"]')
+    expect(placeholder).toBeTruthy()
+  })
+
+  it('click calls onOpen with collection object', () => {
+    const onOpen = vi.fn()
+    render(<CollectionCard collection={COLLECTION} albums={ALBUMS} onOpen={onOpen} />)
+    fireEvent.click(screen.getByTestId('collection-card'))
+    expect(onOpen).toHaveBeenCalledTimes(1)
+    expect(onOpen).toHaveBeenCalledWith(COLLECTION)
+  })
+
+  it('renders collection name as text', () => {
+    render(<CollectionCard collection={COLLECTION} albums={ALBUMS} onOpen={() => {}} />)
+    expect(screen.getByText('My Collection')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/CollectionDetailHeader.jsx
+++ b/frontend/src/components/CollectionDetailHeader.jsx
@@ -1,8 +1,22 @@
 import { useState } from 'react'
+import TagPickerInput from './TagPickerInput'
 
-export default function CollectionDetailHeader({ name, description, albumCount, onBack, onDescriptionChange, onRename }) {
+export default function CollectionDetailHeader({
+  name,
+  description,
+  albumCount,
+  onBack,
+  onDescriptionChange,
+  onRename,
+  allTags,
+  selectedTagIds,
+  onTagsChange,
+  onCreateTag,
+}) {
   const [editName, setEditName] = useState(name || '')
   const [desc, setDesc] = useState(description || '')
+  const showTagPicker =
+    Array.isArray(allTags) && typeof onTagsChange === 'function'
 
   function handleNameBlur() {
     const trimmed = editName.trim()
@@ -21,27 +35,39 @@ export default function CollectionDetailHeader({ name, description, albumCount, 
   }
 
   return (
-    <div className="flex items-center gap-3 px-4 py-2 border-b border-border bg-surface flex-shrink-0">
-      <button className="text-sm text-text-dim transition-colors duration-150 hover:text-text" onClick={onBack}>← Back</button>
-      <div className="flex-1 min-w-0">
-        <input
-          className="text-base font-semibold bg-transparent border-none w-full p-0 outline-none"
-          placeholder="Collection name"
-          value={editName}
-          onChange={e => setEditName(e.target.value)}
-          onBlur={handleNameBlur}
-          onKeyDown={e => e.key === 'Enter' && e.target.blur()}
-        />
-        <input
-          className="bg-transparent border-none text-xs text-text-dim w-full p-0 outline-none"
-          placeholder="Add a description…"
-          value={desc}
-          onChange={e => setDesc(e.target.value)}
-          onBlur={handleDescBlur}
-          onKeyDown={e => e.key === 'Enter' && e.target.blur()}
-        />
+    <div className="px-4 py-2 border-b border-border bg-surface flex-shrink-0">
+      <div className="flex items-center gap-3">
+        <button className="text-sm text-text-dim transition-colors duration-150 hover:text-text" onClick={onBack}>← Back</button>
+        <div className="flex-1 min-w-0">
+          <input
+            className="text-base font-semibold bg-transparent border-none w-full p-0 outline-none"
+            placeholder="Collection name"
+            value={editName}
+            onChange={e => setEditName(e.target.value)}
+            onBlur={handleNameBlur}
+            onKeyDown={e => e.key === 'Enter' && e.target.blur()}
+          />
+          <input
+            className="bg-transparent border-none text-xs text-text-dim w-full p-0 outline-none"
+            placeholder="Add a description…"
+            value={desc}
+            onChange={e => setDesc(e.target.value)}
+            onBlur={handleDescBlur}
+            onKeyDown={e => e.key === 'Enter' && e.target.blur()}
+          />
+        </div>
+        <span className="text-sm text-text-dim flex-shrink-0">{albumCount} albums</span>
       </div>
-      <span className="text-sm text-text-dim flex-shrink-0">{albumCount} albums</span>
+      {showTagPicker && (
+        <div className="mt-2" data-testid="collection-tag-picker">
+          <TagPickerInput
+            allTags={allTags}
+            selectedTagIds={selectedTagIds ?? []}
+            onChange={onTagsChange}
+            onCreate={onCreateTag}
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/CollectionDetailHeader.test.jsx
+++ b/frontend/src/components/CollectionDetailHeader.test.jsx
@@ -143,6 +143,67 @@ describe('CollectionDetailHeader', () => {
     expect(onRename).not.toHaveBeenCalled()
   })
 
+  it('renders the TagPickerInput when tag picker props are provided', () => {
+    const allTags = [
+      { id: 'tag-1', name: 'mood', parent_tag_id: null, position: 0 },
+      { id: 'tag-2', name: 'energy', parent_tag_id: null, position: 1 },
+    ]
+    render(
+      <CollectionDetailHeader
+        name="Late Night"
+        description={null}
+        albumCount={5}
+        onBack={() => {}}
+        onDescriptionChange={() => {}}
+        allTags={allTags}
+        selectedTagIds={['tag-1']}
+        onTagsChange={() => {}}
+        onCreateTag={async () => null}
+      />
+    )
+    expect(screen.getByTestId('collection-tag-picker')).toBeInTheDocument()
+    // Currently-applied tag chip is shown
+    expect(screen.getByText('mood')).toBeInTheDocument()
+    // The remove button for the chip exists, proving onChange wiring path
+    expect(screen.getByRole('button', { name: /remove mood/i })).toBeInTheDocument()
+  })
+
+  it('removing a tag chip calls onTagsChange with the new id list', async () => {
+    const onTagsChange = vi.fn()
+    const allTags = [
+      { id: 'tag-1', name: 'mood', parent_tag_id: null, position: 0 },
+      { id: 'tag-2', name: 'energy', parent_tag_id: null, position: 1 },
+    ]
+    render(
+      <CollectionDetailHeader
+        name="Late Night"
+        description={null}
+        albumCount={5}
+        onBack={() => {}}
+        onDescriptionChange={() => {}}
+        allTags={allTags}
+        selectedTagIds={['tag-1', 'tag-2']}
+        onTagsChange={onTagsChange}
+        onCreateTag={async () => null}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /remove mood/i }))
+    expect(onTagsChange).toHaveBeenCalledWith(['tag-2'])
+  })
+
+  it('does not render the tag picker when tag props are absent', () => {
+    render(
+      <CollectionDetailHeader
+        name="Late Night"
+        description={null}
+        albumCount={5}
+        onBack={() => {}}
+        onDescriptionChange={() => {}}
+      />
+    )
+    expect(screen.queryByTestId('collection-tag-picker')).not.toBeInTheDocument()
+  })
+
   it('submits name on Enter key', async () => {
     const onRename = vi.fn()
     render(

--- a/frontend/src/components/CollectionGrid.jsx
+++ b/frontend/src/components/CollectionGrid.jsx
@@ -1,0 +1,22 @@
+import CollectionCard from './CollectionCard'
+
+export default function CollectionGrid({ collections, albumsByCollection, onOpen }) {
+  if (!collections || collections.length === 0) {
+    return (
+      <div className="p-4 text-sm text-text-dim italic">No collections yet</div>
+    )
+  }
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 p-3">
+      {collections.map(collection => (
+        <CollectionCard
+          key={collection.id}
+          collection={collection}
+          albums={albumsByCollection?.[collection.id] ?? []}
+          onOpen={onOpen}
+        />
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/CollectionGrid.jsx
+++ b/frontend/src/components/CollectionGrid.jsx
@@ -8,7 +8,7 @@ export default function CollectionGrid({ collections, albumsByCollection, onOpen
   }
 
   return (
-    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 p-3">
+    <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-8 gap-2 p-3">
       {collections.map(collection => (
         <CollectionCard
           key={collection.id}

--- a/frontend/src/components/CollectionGrid.test.jsx
+++ b/frontend/src/components/CollectionGrid.test.jsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react'
+import CollectionGrid from './CollectionGrid'
+
+const COLLECTIONS = [
+  { id: 'c1', name: 'First' },
+  { id: 'c2', name: 'Second' },
+  { id: 'c3', name: 'Third' },
+]
+
+const ALBUMS_BY_COLLECTION = {
+  c1: [
+    { service_id: 'a1', name: 'A1', image_url: 'http://img/1.jpg' },
+  ],
+  c2: [
+    { service_id: 'a2', name: 'A2', image_url: 'http://img/2.jpg' },
+    { service_id: 'a3', name: 'A3', image_url: 'http://img/3.jpg' },
+  ],
+  c3: [],
+}
+
+describe('CollectionGrid', () => {
+  it('renders one card per collection', () => {
+    render(<CollectionGrid collections={COLLECTIONS} albumsByCollection={ALBUMS_BY_COLLECTION} onOpen={() => {}} />)
+    const cards = screen.getAllByTestId('collection-card')
+    expect(cards).toHaveLength(3)
+  })
+
+  it('shows empty state when collections empty', () => {
+    render(<CollectionGrid collections={[]} albumsByCollection={{}} onOpen={() => {}} />)
+    expect(screen.getByText('No collections yet')).toBeInTheDocument()
+  })
+
+  it('passes correct albums to each card from albumsByCollection', () => {
+    render(<CollectionGrid collections={COLLECTIONS} albumsByCollection={ALBUMS_BY_COLLECTION} onOpen={() => {}} />)
+    // c1 has 1 album, c2 has 2, c3 has 0 -> total 3 imgs across mosaics
+    const images = screen.getAllByRole('img')
+    expect(images).toHaveLength(3)
+    expect(images.map(i => i.getAttribute('src'))).toEqual([
+      'http://img/1.jpg',
+      'http://img/2.jpg',
+      'http://img/3.jpg',
+    ])
+  })
+
+  it('passes empty array when collection missing from albumsByCollection', () => {
+    render(<CollectionGrid collections={[{ id: 'cx', name: 'X' }]} albumsByCollection={{}} onOpen={() => {}} />)
+    const cards = screen.getAllByTestId('collection-card')
+    expect(cards).toHaveLength(1)
+    expect(screen.queryAllByRole('img')).toHaveLength(0)
+  })
+})

--- a/frontend/src/components/CollectionList.jsx
+++ b/frontend/src/components/CollectionList.jsx
@@ -1,0 +1,287 @@
+import { useEffect, useMemo, useState } from 'react'
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  useSortable,
+  arrayMove,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import AlbumArtStrip from './AlbumArtStrip'
+
+const ROW_HEIGHT = 40
+const THUMB_SIZE = 28
+const MAX_THUMBS = 4
+
+// Exported for unit tests — pure helper that computes the reordered id list.
+export function __computeReorder(orderedIds, activeId, overId) {
+  if (activeId === overId) return orderedIds
+  const oldIndex = orderedIds.indexOf(activeId)
+  const newIndex = orderedIds.indexOf(overId)
+  if (oldIndex < 0 || newIndex < 0) return orderedIds
+  return arrayMove(orderedIds, oldIndex, newIndex)
+}
+
+function CollectionRow({
+  col,
+  artAlbums,
+  renamingId,
+  renameValue,
+  setRenameValue,
+  setRenamingId,
+  submitRename,
+  confirmingId,
+  setConfirmingId,
+  menuOpenId,
+  setMenuOpenId,
+  handleDeleteClick,
+  handleConfirmDelete,
+  handleCancelDelete,
+  onOpen,
+  onManageTags,
+  dragHandleProps,
+  sortableRef,
+  sortableStyle,
+}) {
+  const isConfirming = confirmingId === col.id
+  const isRenaming = renamingId === col.id
+  const isMenuOpen = menuOpenId === col.id
+
+  return (
+    <div
+      ref={sortableRef}
+      style={{ ...sortableStyle, height: ROW_HEIGHT }}
+      data-testid="collection-list-row"
+      className="flex items-center gap-2 px-2 border-b border-border cursor-pointer hover:bg-bg-elevated transition-colors duration-150 group"
+      onClick={() => {
+        if (isRenaming) return
+        onOpen?.(col)
+      }}
+      onMouseLeave={() => {
+        if (isMenuOpen) setMenuOpenId(null)
+        if (isConfirming) setConfirmingId(null)
+      }}
+    >
+      {dragHandleProps && (
+        <button
+          aria-label="Drag to reorder"
+          className="drag-handle bg-transparent border-none text-text-dim cursor-grab p-0 text-base touch-none flex-shrink-0"
+          onClick={(e) => e.stopPropagation()}
+          {...dragHandleProps}
+        >
+          ⠿
+        </button>
+      )}
+      <div className="flex-shrink-0" style={{ height: THUMB_SIZE }}>
+        <AlbumArtStrip albums={(artAlbums || []).slice(0, MAX_THUMBS)} size={THUMB_SIZE} />
+      </div>
+      <div className="min-w-0 flex-1 flex items-center">
+        {isRenaming ? (
+          <input
+            className="text-sm font-medium text-text bg-transparent border-b border-accent outline-none w-full"
+            value={renameValue}
+            onChange={(e) => setRenameValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') submitRename(col)
+              if (e.key === 'Escape') setRenamingId(null)
+            }}
+            onBlur={() => submitRename(col)}
+            autoFocus
+            onClick={(e) => e.stopPropagation()}
+          />
+        ) : (
+          <span className="text-sm text-text truncate">{col.name}</span>
+        )}
+      </div>
+      {col.album_count != null && !isRenaming && (
+        <span className="text-xs text-text-dim flex-shrink-0">{col.album_count}</span>
+      )}
+      <div onClick={(e) => e.stopPropagation()} className="relative flex-shrink-0">
+        {isRenaming ? null : isConfirming ? (
+          <div className="flex items-center gap-0.5">
+            <button
+              className="bg-delete-red border-none text-white cursor-pointer text-xs font-semibold px-1.5 py-0.5 rounded whitespace-nowrap"
+              aria-label="Confirm delete"
+              onClick={(e) => handleConfirmDelete(e, col.id)}
+            >
+              Delete
+            </button>
+            <button
+              className="bg-transparent border border-border text-text-dim cursor-pointer text-xs px-1.5 py-0.5 rounded whitespace-nowrap"
+              aria-label="Cancel"
+              onClick={handleCancelDelete}
+            >
+              Cancel
+            </button>
+          </div>
+        ) : isMenuOpen ? (
+          <div className="flex items-center gap-1">
+            <button
+              className="bg-transparent border border-border text-text text-xs px-2 py-0.5 rounded cursor-pointer hover:bg-bg-elevated"
+              onClick={() => {
+                setMenuOpenId(null)
+                setRenamingId(col.id)
+                setRenameValue(col.name)
+              }}
+            >
+              Rename
+            </button>
+            <button
+              className="bg-transparent border border-border text-text text-xs px-2 py-0.5 rounded cursor-pointer hover:bg-bg-elevated"
+              onClick={() => {
+                setMenuOpenId(null)
+                onManageTags?.(col)
+              }}
+            >
+              Manage tags
+            </button>
+            <button
+              className="bg-transparent border border-border text-delete-red text-xs px-2 py-0.5 rounded cursor-pointer hover:bg-bg-elevated"
+              onClick={(e) => {
+                setMenuOpenId(null)
+                handleDeleteClick(e, col.id)
+              }}
+            >
+              Delete
+            </button>
+          </div>
+        ) : (
+          <button
+            className="bg-transparent border-none text-text-dim cursor-pointer text-base p-1 rounded opacity-0 group-hover:opacity-50 hover:!opacity-100 hover:text-text-hover transition-opacity duration-150"
+            aria-label="More options"
+            onClick={() => setMenuOpenId(col.id)}
+          >
+            ⋯
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function SortableCollectionRow({ col, ...rest }) {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: col.id })
+  const style = { transform: CSS.Transform.toString(transform), transition }
+  return (
+    <CollectionRow
+      col={col}
+      sortableRef={setNodeRef}
+      sortableStyle={style}
+      dragHandleProps={{ ...attributes, ...listeners }}
+      {...rest}
+    />
+  )
+}
+
+export default function CollectionList({
+  collections,
+  albumsByCollection,
+  onOpen,
+  onRename,
+  onDelete,
+  onReorder,
+  onManageTags,
+}) {
+  const [confirmingId, setConfirmingId] = useState(null)
+  const [menuOpenId, setMenuOpenId] = useState(null)
+  const [renamingId, setRenamingId] = useState(null)
+  const [renameValue, setRenameValue] = useState('')
+
+  useEffect(() => {
+    if (!confirmingId && !menuOpenId) return
+    function handleDocClick() {
+      setConfirmingId(null)
+      setMenuOpenId(null)
+    }
+    const id = setTimeout(() => {
+      document.addEventListener('click', handleDocClick)
+    }, 0)
+    return () => {
+      clearTimeout(id)
+      document.removeEventListener('click', handleDocClick)
+    }
+  }, [confirmingId, menuOpenId])
+
+  function handleDeleteClick(e, colId) {
+    e.stopPropagation()
+    if (confirmingId !== colId) setConfirmingId(colId)
+  }
+
+  function handleConfirmDelete(e, colId) {
+    e.stopPropagation()
+    onDelete?.(colId)
+    setConfirmingId(null)
+  }
+
+  function handleCancelDelete(e) {
+    e.stopPropagation()
+    setConfirmingId(null)
+  }
+
+  function submitRename(col) {
+    const trimmed = renameValue.trim()
+    if (trimmed && trimmed !== col.name) {
+      onRename?.(col.id, trimmed)
+    }
+    setRenamingId(null)
+  }
+
+  const sensors = useSensors(useSensor(PointerSensor), useSensor(KeyboardSensor))
+  const sortableIds = useMemo(() => collections.map((c) => c.id), [collections])
+
+  function handleDragEnd(event) {
+    const { active, over } = event
+    if (!over) return
+    const newOrder = __computeReorder(sortableIds, active.id, over.id)
+    if (newOrder !== sortableIds) onReorder?.(newOrder)
+  }
+
+  if (!collections || collections.length === 0) {
+    return <p className="p-4 text-sm text-text-dim italic">No collections yet.</p>
+  }
+
+  const rowProps = {
+    renamingId,
+    renameValue,
+    setRenameValue,
+    setRenamingId,
+    submitRename,
+    confirmingId,
+    setConfirmingId,
+    menuOpenId,
+    setMenuOpenId,
+    handleDeleteClick,
+    handleConfirmDelete,
+    handleCancelDelete,
+    onOpen,
+    onManageTags,
+  }
+
+  function renderRow(col) {
+    const artAlbums = (albumsByCollection && albumsByCollection[col.id]) || []
+    if (onReorder) {
+      return <SortableCollectionRow key={col.id} col={col} artAlbums={artAlbums} {...rowProps} />
+    }
+    return <CollectionRow key={col.id} col={col} artAlbums={artAlbums} {...rowProps} />
+  }
+
+  const list = <div className="flex flex-col">{collections.map(renderRow)}</div>
+
+  if (onReorder) {
+    return (
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
+          {list}
+        </SortableContext>
+      </DndContext>
+    )
+  }
+  return list
+}

--- a/frontend/src/components/CollectionList.jsx
+++ b/frontend/src/components/CollectionList.jsx
@@ -79,9 +79,6 @@ function CollectionRow({
           ⠿
         </button>
       )}
-      <div className="flex-shrink-0" style={{ height: THUMB_SIZE }}>
-        <AlbumArtStrip albums={(artAlbums || []).slice(0, MAX_THUMBS)} size={THUMB_SIZE} />
-      </div>
       <div className="min-w-0 flex-1 flex items-center">
         {isRenaming ? (
           <input
@@ -99,6 +96,9 @@ function CollectionRow({
         ) : (
           <span className="text-sm text-text truncate">{col.name}</span>
         )}
+      </div>
+      <div className="flex-shrink-0" style={{ height: THUMB_SIZE }}>
+        <AlbumArtStrip albums={(artAlbums || []).slice(0, MAX_THUMBS)} size={THUMB_SIZE} />
       </div>
       {col.album_count != null && !isRenaming && (
         <span className="text-xs text-text-dim flex-shrink-0">{col.album_count}</span>

--- a/frontend/src/components/CollectionList.test.jsx
+++ b/frontend/src/components/CollectionList.test.jsx
@@ -1,0 +1,182 @@
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import CollectionList, { __computeReorder } from './CollectionList'
+
+const COLLECTIONS = [
+  { id: 'col-1', name: 'Road trip', album_count: 5 },
+  { id: 'col-2', name: '90s classics', album_count: 12 },
+]
+
+const ALBUMS_BY_COL = {
+  'col-1': [
+    { service_id: 'a1', name: 'In Rainbows', image_url: 'http://img/1.jpg' },
+    { service_id: 'a2', name: 'OK Computer', image_url: 'http://img/2.jpg' },
+  ],
+  'col-2': [],
+}
+
+const noop = () => {}
+
+function renderList(overrides = {}) {
+  const props = {
+    collections: COLLECTIONS,
+    albumsByCollection: ALBUMS_BY_COL,
+    onOpen: noop,
+    onRename: noop,
+    onDelete: noop,
+    onReorder: noop,
+    onManageTags: noop,
+    ...overrides,
+  }
+  return render(<CollectionList {...props} />)
+}
+
+describe('CollectionList', () => {
+  it('renders one row per collection', () => {
+    renderList()
+    const rows = screen.getAllByTestId('collection-list-row')
+    expect(rows).toHaveLength(2)
+    expect(screen.getByText('Road trip')).toBeInTheDocument()
+    expect(screen.getByText('90s classics')).toBeInTheDocument()
+  })
+
+  it('renders empty state when collections is empty', () => {
+    renderList({ collections: [] })
+    expect(screen.getByText(/no collections/i)).toBeInTheDocument()
+  })
+
+  it('row click fires onOpen with collection object', async () => {
+    const onOpen = vi.fn()
+    renderList({ onOpen })
+    await userEvent.click(screen.getByText('Road trip'))
+    expect(onOpen).toHaveBeenCalledWith(COLLECTIONS[0])
+  })
+
+  it('renders the album count for each collection', () => {
+    renderList()
+    expect(screen.getByText('5')).toBeInTheDocument()
+    expect(screen.getByText('12')).toBeInTheDocument()
+  })
+
+  it('renders album art thumbnails at 28px from albumsByCollection', () => {
+    renderList()
+    const img = screen.getByAltText('In Rainbows')
+    expect(img).toBeInTheDocument()
+    expect(img).toHaveAttribute('width', '28')
+  })
+
+  it('shows overflow menu with Rename, Delete, Manage tags actions', async () => {
+    renderList()
+    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
+    expect(screen.getByRole('button', { name: /^rename$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /manage tags/i })).toBeInTheDocument()
+  })
+
+  it('clicking the menu button does not fire onOpen', async () => {
+    const onOpen = vi.fn()
+    renderList({ onOpen })
+    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
+    expect(onOpen).not.toHaveBeenCalled()
+  })
+
+  it('inline rename: enters edit mode, typing + Enter calls onRename', async () => {
+    const onRename = vi.fn()
+    renderList({ onRename })
+    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
+    await userEvent.click(screen.getByRole('button', { name: /^rename$/i }))
+    const input = screen.getByDisplayValue('Road trip')
+    await userEvent.clear(input)
+    await userEvent.type(input, 'Summer vibes{Enter}')
+    expect(onRename).toHaveBeenCalledWith('col-1', 'Summer vibes')
+  })
+
+  it('inline rename: blur saves change', async () => {
+    const onRename = vi.fn()
+    renderList({ onRename })
+    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
+    await userEvent.click(screen.getByRole('button', { name: /^rename$/i }))
+    const input = screen.getByDisplayValue('Road trip')
+    await userEvent.clear(input)
+    await userEvent.type(input, 'New name')
+    await act(async () => { input.blur() })
+    expect(onRename).toHaveBeenCalledWith('col-1', 'New name')
+  })
+
+  it('inline rename: Escape cancels without calling onRename', async () => {
+    const onRename = vi.fn()
+    renderList({ onRename })
+    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
+    await userEvent.click(screen.getByRole('button', { name: /^rename$/i }))
+    await userEvent.keyboard('{Escape}')
+    expect(onRename).not.toHaveBeenCalled()
+    expect(screen.getByText('Road trip')).toBeInTheDocument()
+  })
+
+  it('delete with confirm: first click shows confirm UI, second click fires onDelete', async () => {
+    const onDelete = vi.fn()
+    renderList({ onDelete })
+    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
+    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+    // Confirm UI visible
+    const confirmBtn = screen.getByRole('button', { name: /confirm delete/i })
+    expect(confirmBtn).toBeInTheDocument()
+    expect(onDelete).not.toHaveBeenCalled()
+    await userEvent.click(confirmBtn)
+    expect(onDelete).toHaveBeenCalledWith('col-1')
+  })
+
+  it('delete cancel does not call onDelete', async () => {
+    const onDelete = vi.fn()
+    renderList({ onDelete })
+    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
+    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+    await userEvent.click(screen.getByRole('button', { name: /^cancel$/i }))
+    expect(onDelete).not.toHaveBeenCalled()
+  })
+
+  it('Manage tags overflow action fires onManageTags with collection', async () => {
+    const onManageTags = vi.fn()
+    renderList({ onManageTags })
+    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
+    await userEvent.click(screen.getByRole('button', { name: /manage tags/i }))
+    expect(onManageTags).toHaveBeenCalledWith(COLLECTIONS[0])
+  })
+
+  it('renders drag handles when onReorder is provided', () => {
+    renderList()
+    expect(screen.getAllByRole('button', { name: /drag to reorder/i })).toHaveLength(2)
+  })
+
+  it('does not render drag handles when onReorder is not provided', () => {
+    renderList({ onReorder: undefined })
+    expect(screen.queryByRole('button', { name: /drag to reorder/i })).not.toBeInTheDocument()
+  })
+
+  it('exposes a reorder handler that fires onReorder with new id order (arrayMove pattern)', () => {
+    // The component wires dnd-kit's onDragEnd internally; here we verify the
+    // handleDragEnd computation by exposing it via a ref-like prop test would
+    // require simulating a full drag in jsdom (which dnd-kit cannot do).
+    // Instead, we directly call the exported helper via import.
+    const onReorder = vi.fn()
+    renderList({ onReorder })
+    // CollectionList exports an internal __computeReorder helper for tests.
+    const newIds = __computeReorder(['col-1', 'col-2'], 'col-1', 'col-2')
+    expect(newIds).toEqual(['col-2', 'col-1'])
+  })
+
+  it('row height is approximately 40px (denser than 62px)', () => {
+    renderList()
+    const row = screen.getAllByTestId('collection-list-row')[0]
+    // Either explicit height style or class containing h-10 / h-[40px]
+    const inline = row.getAttribute('style') || ''
+    const cls = row.className || ''
+    const matches =
+      /height:\s*40px/.test(inline) ||
+      /h-10\b/.test(cls) ||
+      /h-\[40px\]/.test(cls) ||
+      // descendants may carry the height
+      !!row.querySelector('[style*="height: 40px"], [style*="height:40px"], .h-10, .h-\\[40px\\]')
+    expect(matches).toBe(true)
+  })
+})

--- a/frontend/src/components/CollectionsPane.jsx
+++ b/frontend/src/components/CollectionsPane.jsx
@@ -9,6 +9,7 @@ import { TagTreeSidebar } from './TagTreeSidebar'
 import { ViewToggle } from './ViewToggle'
 import CollectionGrid from './CollectionGrid'
 import CollectionList from './CollectionList'
+import TagDrillPage from './TagDrillPage'
 import { buildTagTree, getDescendantIds } from '../lib/tagTree'
 
 // --- Legacy mobile row ---
@@ -237,91 +238,31 @@ export default function CollectionsPane({
     [collections, tags, selectedTagId, collectionTagsMap],
   )
 
-  // ---- Mobile branch (legacy) ----
+  // ---- Mobile branch (drill-down) ----
   if (isMobile) {
-    const rowProps = {
-      renamingId,
-      renameValue,
-      setRenameValue,
-      setRenamingId,
-      submitRename,
-      confirmingId,
-      setConfirmingId,
-      menuOpenId,
-      setMenuOpenId,
-      handleDeleteClick,
-      handleConfirmDelete,
-      handleCancelDelete,
-      onEnter,
-    }
-    function renderRow(col) {
-      const artEntry = artMap[col.id]
-      const artAlbums = artEntry ? artEntry.albums : []
-      if (onReorder) {
-        return <SortableCollectionRow key={col.id} col={col} artAlbums={artAlbums} {...rowProps} />
-      }
-      return <CollectionRow key={col.id} col={col} artAlbums={artAlbums} {...rowProps} />
-    }
-    const rowList = (
-      <div className="flex-1 overflow-y-auto">
-        {collections.map(renderRow)}
-      </div>
+    const servingPlatter = (
+      <AlbumPromptBar
+        albumCollectionMap={albumCollectionMap || {}}
+        collections={collectionsForPicker || []}
+        session={session}
+        onBulkAdd={async (collectionId, albumIds) => {
+          if (onBulkAdd) await onBulkAdd(collectionId, albumIds)
+          await refreshCollectionArt(collectionId)
+        }}
+        onCreate={onCreateCollection || (() => {})}
+      />
     )
     return (
-      <div className="w-full flex flex-col h-full overflow-hidden">
-        <div className="flex items-center px-4 py-2 border-b border-border flex-shrink-0">
-          {showCreate ? (
-            <input
-              autoFocus
-              className="bg-surface-2 text-text border border-border rounded-full px-3 py-1 text-sm flex-1 min-w-0"
-              placeholder="Collection name…"
-              value={createName}
-              onChange={e => onCreateNameChange(e.target.value)}
-              onKeyDown={e => {
-                if (e.key === 'Enter' && createName.trim()) {
-                  onCreateSubmit(createName.trim())
-                } else if (e.key === 'Escape') {
-                  onShowCreateChange(false)
-                }
-              }}
-              onBlur={() => onShowCreateChange(false)}
-            />
-          ) : (
-            <button
-              className="bg-transparent border-none text-text-dim cursor-pointer p-1.5 rounded transition-colors duration-150 hover:text-text"
-              onClick={() => onShowCreateChange(true)}
-              aria-label="Create collection"
-            >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                <circle cx="12" cy="12" r="10" />
-                <path d="M12 8v8" />
-                <path d="M8 12h8" />
-              </svg>
-            </button>
-          )}
-        </div>
-        {collections.length === 0 ? (
-          <p className="p-4 text-sm text-text-dim italic">No collections yet.</p>
-        ) : onReorder ? (
-          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-            <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
-              {rowList}
-            </SortableContext>
-          </DndContext>
-        ) : (
-          rowList
-        )}
-        <AlbumPromptBar
-          albumCollectionMap={albumCollectionMap || {}}
-          collections={collectionsForPicker || []}
-          session={session}
-          onBulkAdd={async (collectionId, albumIds) => {
-            if (onBulkAdd) await onBulkAdd(collectionId, albumIds)
-            await refreshCollectionArt(collectionId)
-          }}
-          onCreate={onCreateCollection || (() => {})}
-        />
-      </div>
+      <TagDrillPage
+        tags={tags || []}
+        collections={collections}
+        collectionTagsMap={collectionTagsMap || {}}
+        albumsByCollection={albumsByCollection}
+        currentTagId={selectedTagId ?? null}
+        onSelectTag={onSelectTag || (() => {})}
+        onOpenCollection={onEnter}
+        servingPlatter={servingPlatter}
+      />
     )
   }
 

--- a/frontend/src/components/CollectionsPane.jsx
+++ b/frontend/src/components/CollectionsPane.jsx
@@ -5,10 +5,17 @@ import { CSS } from '@dnd-kit/utilities'
 import { useIsMobile } from '../hooks/useIsMobile'
 import AlbumArtStrip from './AlbumArtStrip'
 import AlbumPromptBar from './AlbumPromptBar'
+import { TagTreeSidebar } from './TagTreeSidebar'
+import { ViewToggle } from './ViewToggle'
+import CollectionGrid from './CollectionGrid'
+import CollectionList from './CollectionList'
+import { buildTagTree, getDescendantIds } from '../lib/tagTree'
 
-function CollectionRow({ col, isMobile, renamingId, renameValue, setRenameValue, setRenamingId, submitRename, confirmingId, setConfirmingId, menuOpenId, setMenuOpenId, handleDeleteClick, handleConfirmDelete, handleCancelDelete, onEnter, artAlbums, dragHandleProps, sortableRef, sortableStyle }) {
-  const isConfirming = confirmingId === col.id
+// --- Legacy mobile row ---
+// Mobile branch keeps the existing row-with-art-strip rendering until Task 14
+// replaces it with TagDrillPage. Desktop uses the new composition below.
 
+function CollectionRow({ col, renamingId, renameValue, setRenameValue, setRenamingId, submitRename, confirmingId, setConfirmingId, menuOpenId, setMenuOpenId, handleDeleteClick, handleConfirmDelete, handleCancelDelete, onEnter, artAlbums, dragHandleProps, sortableRef, sortableStyle }) {
   return (
     <div
       ref={sortableRef}
@@ -21,121 +28,60 @@ function CollectionRow({ col, isMobile, renamingId, renameValue, setRenameValue,
         if (confirmingId === col.id) setConfirmingId(null)
       }}
     >
-      {isMobile ? (
-        <>
-          <div className="flex items-center justify-between px-4 py-2">
-            {dragHandleProps && (
-              <button
-                aria-label="Drag to reorder"
-                className="drag-handle bg-transparent border-none text-text-dim cursor-grab p-0 text-lg touch-none ml-1 mr-2"
-                onClick={(e) => e.stopPropagation()}
-                {...dragHandleProps}
-              >⠿</button>
+      <div className="flex items-center justify-between px-4 py-2">
+        {dragHandleProps && (
+          <button
+            aria-label="Drag to reorder"
+            className="drag-handle bg-transparent border-none text-text-dim cursor-grab p-0 text-lg touch-none ml-1 mr-2"
+            onClick={(e) => e.stopPropagation()}
+            {...dragHandleProps}
+          >⠿</button>
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            {renamingId === col.id ? (
+              <input
+                className="text-sm font-medium text-text bg-transparent border-b border-accent outline-none w-full"
+                value={renameValue}
+                onChange={e => setRenameValue(e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') submitRename(col)
+                  if (e.key === 'Escape') { setRenamingId(null) }
+                }}
+                onBlur={() => submitRename(col)}
+                autoFocus
+                onClick={e => e.stopPropagation()}
+              />
+            ) : (
+              <span className="text-sm font-medium text-text">{col.name}</span>
             )}
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-2">
-                {renamingId === col.id ? (
-                  <input
-                    className="text-sm font-medium text-text bg-transparent border-b border-accent outline-none w-full"
-                    value={renameValue}
-                    onChange={e => setRenameValue(e.target.value)}
-                    onKeyDown={e => {
-                      if (e.key === 'Enter') submitRename(col)
-                      if (e.key === 'Escape') { setRenamingId(null) }
-                    }}
-                    onBlur={() => submitRename(col)}
-                    autoFocus
-                    onClick={e => e.stopPropagation()}
-                  />
-                ) : (
-                  <span className="text-sm font-medium text-text">{col.name}</span>
-                )}
-              </div>
-              {col.album_count != null && (
-                <div className="text-xs text-text-dim mt-0.5">{col.album_count} {col.album_count === 1 ? 'album' : 'albums'}</div>
-              )}
-              {col.description && (
-                <div className="text-xs text-text-dim mt-0.5 truncate">{col.description}</div>
-              )}
-            </div>
-            <div onClick={e => e.stopPropagation()} className="relative">
-              {renamingId === col.id ? null : confirmingId === col.id ? (
-                <>
-                  <button className="bg-delete-red border-none text-white cursor-pointer text-xs font-semibold px-1.5 py-0.5 rounded mr-0.5 whitespace-nowrap" aria-label="Confirm delete" onClick={e => handleConfirmDelete(e, col.id)}>Delete</button>
-                  <button className="bg-transparent border border-border text-text-dim cursor-pointer text-xs px-1.5 py-0.5 rounded whitespace-nowrap" aria-label="Cancel" onClick={handleCancelDelete}>Cancel</button>
-                </>
-              ) : menuOpenId === col.id ? (
-                <div className="flex gap-1">
-                  <button className="bg-transparent border border-border text-text text-xs px-2 py-1 rounded cursor-pointer hover:bg-surface-2" onClick={() => { setMenuOpenId(null); setRenamingId(col.id); setRenameValue(col.name) }}>Rename</button>
-                  <button className="bg-transparent border border-border text-delete-red text-xs px-2 py-1 rounded cursor-pointer hover:bg-surface-2" onClick={e => { setMenuOpenId(null); handleDeleteClick(e, col.id) }}>Delete</button>
-                </div>
-              ) : (
-                <button className="bg-transparent border-none text-text-dim cursor-pointer text-lg p-1.5 rounded opacity-0 group-hover:opacity-50 hover:!opacity-100 hover:bg-surface-2 transition-opacity duration-150" aria-label="More options" onClick={() => setMenuOpenId(col.id)}>⋯</button>
-              )}
-            </div>
           </div>
-          <div style={{ height: 62 }}>
-            <AlbumArtStrip albums={artAlbums} size={62} />
-          </div>
-        </>
-      ) : (
-        <div className="flex items-stretch" style={{ height: 62 }}>
-          {dragHandleProps && (
-            <div className="flex items-center px-2">
-              <button
-                aria-label="Drag to reorder"
-                className="drag-handle bg-transparent border-none text-text-dim cursor-grab p-0 text-lg touch-none"
-                onClick={(e) => e.stopPropagation()}
-                {...dragHandleProps}
-              >⠿</button>
-            </div>
+          {col.album_count != null && (
+            <div className="text-xs text-text-dim mt-0.5">{col.album_count} {col.album_count === 1 ? 'album' : 'albums'}</div>
           )}
-          <div className="w-48 flex-shrink-0 flex items-center px-4">
-            <div className="min-w-0">
-              {renamingId === col.id ? (
-                <input
-                  className="text-sm font-medium text-text bg-transparent border-b border-accent outline-none w-full"
-                  value={renameValue}
-                  onChange={e => setRenameValue(e.target.value)}
-                  onKeyDown={e => {
-                    if (e.key === 'Enter') submitRename(col)
-                    if (e.key === 'Escape') { setRenamingId(null) }
-                  }}
-                  onBlur={() => submitRename(col)}
-                  autoFocus
-                  onClick={e => e.stopPropagation()}
-                />
-              ) : (
-                <div className="text-sm font-medium text-text truncate">{col.name}</div>
-              )}
-              {col.album_count != null && (
-                <div className="text-xs text-text-dim mt-0.5">{col.album_count} {col.album_count === 1 ? 'album' : 'albums'}</div>
-              )}
-              {col.description && (
-                <div className="text-xs text-text-dim mt-0.5 truncate">{col.description}</div>
-              )}
-            </div>
-          </div>
-          <div className="flex-1 min-w-0 flex items-center relative">
-            <AlbumArtStrip albums={artAlbums} size={62} />
-            <div onClick={e => e.stopPropagation()} className="absolute right-2 top-0 bottom-0 flex items-center opacity-0 group-hover:opacity-100 transition-opacity duration-150">
-              {renamingId === col.id ? null : confirmingId === col.id ? (
-                <div className="flex items-center gap-0.5 bg-surface/80 backdrop-blur-sm rounded-l px-2">
-                  <button className="bg-delete-red border-none text-white cursor-pointer text-xs font-semibold px-1.5 py-0.5 rounded whitespace-nowrap" aria-label="Confirm delete" onClick={e => handleConfirmDelete(e, col.id)}>Delete</button>
-                  <button className="bg-transparent border border-border text-text-dim cursor-pointer text-xs px-1.5 py-0.5 rounded whitespace-nowrap" aria-label="Cancel" onClick={handleCancelDelete}>Cancel</button>
-                </div>
-              ) : menuOpenId === col.id ? (
-                <div className="flex items-center gap-1 bg-surface/80 backdrop-blur-sm rounded-l px-2">
-                  <button className="bg-transparent border border-border text-text text-xs px-2 py-1 rounded cursor-pointer hover:bg-surface-2" onClick={() => { setMenuOpenId(null); setRenamingId(col.id); setRenameValue(col.name) }}>Rename</button>
-                  <button className="bg-transparent border border-border text-delete-red text-xs px-2 py-1 rounded cursor-pointer hover:bg-surface-2" onClick={e => { setMenuOpenId(null); handleDeleteClick(e, col.id) }}>Delete</button>
-                </div>
-              ) : (
-                <button className="bg-surface/80 backdrop-blur-sm border-none text-text-dim cursor-pointer text-lg p-1.5 rounded-l hover:text-text transition-colors duration-150" aria-label="More options" onClick={() => setMenuOpenId(col.id)}>⋯</button>
-              )}
-            </div>
-          </div>
+          {col.description && (
+            <div className="text-xs text-text-dim mt-0.5 truncate">{col.description}</div>
+          )}
         </div>
-      )}
+        <div onClick={e => e.stopPropagation()} className="relative">
+          {renamingId === col.id ? null : confirmingId === col.id ? (
+            <>
+              <button className="bg-delete-red border-none text-white cursor-pointer text-xs font-semibold px-1.5 py-0.5 rounded mr-0.5 whitespace-nowrap" aria-label="Confirm delete" onClick={e => handleConfirmDelete(e, col.id)}>Delete</button>
+              <button className="bg-transparent border border-border text-text-dim cursor-pointer text-xs px-1.5 py-0.5 rounded whitespace-nowrap" aria-label="Cancel" onClick={handleCancelDelete}>Cancel</button>
+            </>
+          ) : menuOpenId === col.id ? (
+            <div className="flex gap-1">
+              <button className="bg-transparent border border-border text-text text-xs px-2 py-1 rounded cursor-pointer hover:bg-surface-2" onClick={() => { setMenuOpenId(null); setRenamingId(col.id); setRenameValue(col.name) }}>Rename</button>
+              <button className="bg-transparent border border-border text-delete-red text-xs px-2 py-1 rounded cursor-pointer hover:bg-surface-2" onClick={e => { setMenuOpenId(null); handleDeleteClick(e, col.id) }}>Delete</button>
+            </div>
+          ) : (
+            <button className="bg-transparent border-none text-text-dim cursor-pointer text-lg p-1.5 rounded opacity-0 group-hover:opacity-50 hover:!opacity-100 hover:bg-surface-2 transition-opacity duration-150" aria-label="More options" onClick={() => setMenuOpenId(col.id)}>⋯</button>
+          )}
+        </div>
+      </div>
+      <div style={{ height: 62 }}>
+        <AlbumArtStrip albums={artAlbums} size={62} />
+      </div>
     </div>
   )
 }
@@ -154,14 +100,60 @@ function SortableCollectionRow({ col, ...rest }) {
   )
 }
 
-export default function CollectionsPane({ collections, onEnter, onDelete, onCreate, onRename, onFetchAlbums, albumCollectionMap, collectionsForPicker, session, onBulkAdd, onCreateCollection, onReorder, showCreate, onShowCreateChange, createName, onCreateNameChange, onCreateSubmit }) {
+// Shared filter helper: returns the subset of `collections` that match the
+// currently-selected tag (or all when selectedTagId is null). A collection
+// matches when any of its tag ids appears in the selected tag's descendant set.
+function filterCollectionsByTag(collections, tags, selectedTagId, collectionTagsMap) {
+  if (selectedTagId === null || selectedTagId === undefined) return collections
+  const tree = buildTagTree(tags || [])
+  const allowed = getDescendantIds(tree, selectedTagId)
+  if (allowed.size === 0) return []
+  return collections.filter(c => {
+    const tagIds = (collectionTagsMap || {})[c.id] || []
+    return tagIds.some(id => allowed.has(id))
+  })
+}
+
+// Exported for unit tests of the pure filter logic
+export { filterCollectionsByTag }
+
+export default function CollectionsPane({
+  collections,
+  onEnter,
+  onDelete,
+  onCreate,
+  onRename,
+  onFetchAlbums,
+  albumCollectionMap,
+  collectionsForPicker,
+  session,
+  onBulkAdd,
+  onCreateCollection,
+  onReorder,
+  showCreate,
+  onShowCreateChange,
+  createName,
+  onCreateNameChange,
+  onCreateSubmit,
+  // New props (Task 12)
+  tags,
+  selectedTagId,
+  onSelectTag,
+  viewMode,
+  onViewModeChange,
+  onManageTags,
+  onOpenTagManager,
+  collectionTagsMap,
+}) {
+  const isMobile = useIsMobile()
   const [artMap, setArtMap] = useState({})
   const [confirmingId, setConfirmingId] = useState(null)
   const [menuOpenId, setMenuOpenId] = useState(null)
   const [renamingId, setRenamingId] = useState(null)
   const [renameValue, setRenameValue] = useState('')
-  const isMobile = useIsMobile()
 
+  // Eagerly load album art previews per collection. Used by both the mobile
+  // legacy rows and the desktop grid/list (which take `albumsByCollection`).
   useEffect(() => {
     if (!onFetchAlbums || !collections.length) return
     collections.forEach(col => {
@@ -190,22 +182,17 @@ export default function CollectionsPane({ collections, onEnter, onDelete, onCrea
 
   function handleDeleteClick(e, colId) {
     e.stopPropagation()
-    if (confirmingId !== colId) {
-      setConfirmingId(colId)
-    }
+    if (confirmingId !== colId) setConfirmingId(colId)
   }
-
   function handleConfirmDelete(e, colId) {
     e.stopPropagation()
     onDelete(colId)
     setConfirmingId(null)
   }
-
   function handleCancelDelete(e) {
     e.stopPropagation()
     setConfirmingId(null)
   }
-
   function submitRename(col) {
     const trimmed = renameValue.trim()
     if (trimmed && trimmed !== col.name) {
@@ -214,13 +201,8 @@ export default function CollectionsPane({ collections, onEnter, onDelete, onCrea
     setRenamingId(null)
   }
 
-  const sensors = useSensors(
-    useSensor(PointerSensor),
-    useSensor(KeyboardSensor),
-  )
-
+  const sensors = useSensors(useSensor(PointerSensor), useSensor(KeyboardSensor))
   const sortableIds = useMemo(() => collections.map(c => c.id), [collections])
-
   function handleDragEnd(event) {
     const { active, over } = event
     if (!over || active.id === over.id) return
@@ -230,62 +212,69 @@ export default function CollectionsPane({ collections, onEnter, onDelete, onCrea
     onReorder?.(newOrder)
   }
 
-  const rowProps = {
-    isMobile,
-    renamingId,
-    renameValue,
-    setRenameValue,
-    setRenamingId,
-    submitRename,
-    confirmingId,
-    setConfirmingId,
-    menuOpenId,
-    setMenuOpenId,
-    handleDeleteClick,
-    handleConfirmDelete,
-    handleCancelDelete,
-    onEnter,
+  // albumsByCollection: { [collectionId]: Album[] } derived from the artMap
+  // used for both mobile rows (legacy) and desktop grid/list previews.
+  const albumsByCollection = useMemo(() => {
+    const out = {}
+    Object.entries(artMap).forEach(([colId, entry]) => {
+      out[colId] = entry?.albums || []
+    })
+    return out
+  }, [artMap])
+
+  // Refresh art for a single collection — used after bulk-adding albums via
+  // AlbumPromptBar so the strip updates without re-fetching everything.
+  async function refreshCollectionArt(collectionId) {
+    if (!onFetchAlbums) return
+    const albums = await onFetchAlbums(collectionId)
+    setArtMap(prev => ({ ...prev, [collectionId]: { albums, loading: false } }))
   }
 
-  function renderRow(col) {
-    const artEntry = artMap[col.id]
-    const artAlbums = artEntry ? artEntry.albums : []
-
-    if (onReorder) {
-      return (
-        <SortableCollectionRow
-          key={col.id}
-          col={col}
-          artAlbums={artAlbums}
-          {...rowProps}
-        />
-      )
-    }
-    return (
-      <CollectionRow
-        key={col.id}
-        col={col}
-        artAlbums={artAlbums}
-        {...rowProps}
-      />
-    )
-  }
-
-  const rowList = (
-    <div className="flex-1 overflow-y-auto">
-      {collections.map(col => renderRow(col))}
-    </div>
+  // Compute the filtered set unconditionally so hook order stays stable across
+  // mobile/desktop branches. (Mobile ignores it; desktop renders from it.)
+  const filteredCollections = useMemo(
+    () => filterCollectionsByTag(collections, tags || [], selectedTagId ?? null, collectionTagsMap || {}),
+    [collections, tags, selectedTagId, collectionTagsMap],
   )
 
-  return (
-    <div className="w-full flex flex-col h-full overflow-hidden">
-      {isMobile && (
+  // ---- Mobile branch (legacy) ----
+  if (isMobile) {
+    const rowProps = {
+      renamingId,
+      renameValue,
+      setRenameValue,
+      setRenamingId,
+      submitRename,
+      confirmingId,
+      setConfirmingId,
+      menuOpenId,
+      setMenuOpenId,
+      handleDeleteClick,
+      handleConfirmDelete,
+      handleCancelDelete,
+      onEnter,
+    }
+    function renderRow(col) {
+      const artEntry = artMap[col.id]
+      const artAlbums = artEntry ? artEntry.albums : []
+      if (onReorder) {
+        return <SortableCollectionRow key={col.id} col={col} artAlbums={artAlbums} {...rowProps} />
+      }
+      return <CollectionRow key={col.id} col={col} artAlbums={artAlbums} {...rowProps} />
+    }
+    const rowList = (
+      <div className="flex-1 overflow-y-auto">
+        {collections.map(renderRow)}
+      </div>
+    )
+    return (
+      <div className="w-full flex flex-col h-full overflow-hidden">
         <div className="flex items-center px-4 py-2 border-b border-border flex-shrink-0">
           {showCreate ? (
             <input
               autoFocus
               className="bg-surface-2 text-text border border-border rounded-full px-3 py-1 text-sm flex-1 min-w-0"
-              placeholder="Collection name\u2026"
+              placeholder="Collection name…"
               value={createName}
               onChange={e => onCreateNameChange(e.target.value)}
               onKeyDown={e => {
@@ -311,31 +300,85 @@ export default function CollectionsPane({ collections, onEnter, onDelete, onCrea
             </button>
           )}
         </div>
-      )}
-      {collections.length === 0 ? (
-        <p className="p-4 text-sm text-text-dim italic">No collections yet.</p>
-      ) : onReorder ? (
-        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-          <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
-            {rowList}
-          </SortableContext>
-        </DndContext>
-      ) : (
-        rowList
-      )}
-      <AlbumPromptBar
-        albumCollectionMap={albumCollectionMap || {}}
-        collections={collectionsForPicker || []}
-        session={session}
-        onBulkAdd={async (collectionId, albumIds) => {
-          if (onBulkAdd) await onBulkAdd(collectionId, albumIds)
-          if (onFetchAlbums) {
-            const albums = await onFetchAlbums(collectionId)
-            setArtMap(prev => ({ ...prev, [collectionId]: { albums, loading: false } }))
-          }
-        }}
-        onCreate={onCreateCollection || (() => {})}
+        {collections.length === 0 ? (
+          <p className="p-4 text-sm text-text-dim italic">No collections yet.</p>
+        ) : onReorder ? (
+          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+            <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
+              {rowList}
+            </SortableContext>
+          </DndContext>
+        ) : (
+          rowList
+        )}
+        <AlbumPromptBar
+          albumCollectionMap={albumCollectionMap || {}}
+          collections={collectionsForPicker || []}
+          session={session}
+          onBulkAdd={async (collectionId, albumIds) => {
+            if (onBulkAdd) await onBulkAdd(collectionId, albumIds)
+            await refreshCollectionArt(collectionId)
+          }}
+          onCreate={onCreateCollection || (() => {})}
+        />
+      </div>
+    )
+  }
+
+  // ---- Desktop branch (new composition) ----
+  const effectiveViewMode = viewMode === 'grid' ? 'grid' : 'list'
+
+  return (
+    <div className="flex h-full w-full overflow-hidden">
+      <TagTreeSidebar
+        tags={tags || []}
+        selectedTagId={selectedTagId ?? null}
+        onSelect={onSelectTag || (() => {})}
+        onOpenManager={onOpenTagManager || (() => {})}
       />
+      <div className="flex-1 flex flex-col overflow-hidden">
+        <div className="flex items-center justify-between p-3 border-b border-border flex-shrink-0">
+          <ViewToggle value={effectiveViewMode} onChange={onViewModeChange || (() => {})} />
+          {onCreate && (
+            <button
+              type="button"
+              onClick={() => onCreate()}
+              className="bg-transparent border border-border text-text text-xs px-3 py-1 rounded cursor-pointer hover:bg-bg-elevated"
+            >
+              + New Collection
+            </button>
+          )}
+        </div>
+        <div className="flex-1 overflow-y-auto p-3" data-testid="collections-content">
+          {effectiveViewMode === 'grid' ? (
+            <CollectionGrid
+              collections={filteredCollections}
+              albumsByCollection={albumsByCollection}
+              onOpen={onEnter}
+            />
+          ) : (
+            <CollectionList
+              collections={filteredCollections}
+              albumsByCollection={albumsByCollection}
+              onOpen={onEnter}
+              onRename={onRename}
+              onDelete={onDelete}
+              onReorder={onReorder}
+              onManageTags={onManageTags || onEnter}
+            />
+          )}
+        </div>
+        <AlbumPromptBar
+          albumCollectionMap={albumCollectionMap || {}}
+          collections={collectionsForPicker || []}
+          session={session}
+          onBulkAdd={async (collectionId, albumIds) => {
+            if (onBulkAdd) await onBulkAdd(collectionId, albumIds)
+            await refreshCollectionArt(collectionId)
+          }}
+          onCreate={onCreateCollection || (() => {})}
+        />
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/CollectionsPane.jsx
+++ b/frontend/src/components/CollectionsPane.jsx
@@ -1,9 +1,5 @@
 import { useState, useEffect, useMemo } from 'react'
-import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core'
-import { SortableContext, verticalListSortingStrategy, useSortable, arrayMove } from '@dnd-kit/sortable'
-import { CSS } from '@dnd-kit/utilities'
 import { useIsMobile } from '../hooks/useIsMobile'
-import AlbumArtStrip from './AlbumArtStrip'
 import AlbumPromptBar from './AlbumPromptBar'
 import { TagTreeSidebar } from './TagTreeSidebar'
 import { ViewToggle } from './ViewToggle'
@@ -11,95 +7,6 @@ import CollectionGrid from './CollectionGrid'
 import CollectionList from './CollectionList'
 import TagDrillPage from './TagDrillPage'
 import { buildTagTree, getDescendantIds } from '../lib/tagTree'
-
-// --- Legacy mobile row ---
-// Mobile branch keeps the existing row-with-art-strip rendering until Task 14
-// replaces it with TagDrillPage. Desktop uses the new composition below.
-
-function CollectionRow({ col, renamingId, renameValue, setRenameValue, setRenamingId, submitRename, confirmingId, setConfirmingId, menuOpenId, setMenuOpenId, handleDeleteClick, handleConfirmDelete, handleCancelDelete, onEnter, artAlbums, dragHandleProps, sortableRef, sortableStyle }) {
-  return (
-    <div
-      ref={sortableRef}
-      style={sortableStyle}
-      data-testid="collection-row"
-      className="border-b border-border cursor-pointer hover:bg-hover transition-colors duration-150 group"
-      onClick={() => onEnter(col)}
-      onMouseLeave={() => {
-        if (menuOpenId === col.id) setMenuOpenId(null)
-        if (confirmingId === col.id) setConfirmingId(null)
-      }}
-    >
-      <div className="flex items-center justify-between px-4 py-2">
-        {dragHandleProps && (
-          <button
-            aria-label="Drag to reorder"
-            className="drag-handle bg-transparent border-none text-text-dim cursor-grab p-0 text-lg touch-none ml-1 mr-2"
-            onClick={(e) => e.stopPropagation()}
-            {...dragHandleProps}
-          >⠿</button>
-        )}
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            {renamingId === col.id ? (
-              <input
-                className="text-sm font-medium text-text bg-transparent border-b border-accent outline-none w-full"
-                value={renameValue}
-                onChange={e => setRenameValue(e.target.value)}
-                onKeyDown={e => {
-                  if (e.key === 'Enter') submitRename(col)
-                  if (e.key === 'Escape') { setRenamingId(null) }
-                }}
-                onBlur={() => submitRename(col)}
-                autoFocus
-                onClick={e => e.stopPropagation()}
-              />
-            ) : (
-              <span className="text-sm font-medium text-text">{col.name}</span>
-            )}
-          </div>
-          {col.album_count != null && (
-            <div className="text-xs text-text-dim mt-0.5">{col.album_count} {col.album_count === 1 ? 'album' : 'albums'}</div>
-          )}
-          {col.description && (
-            <div className="text-xs text-text-dim mt-0.5 truncate">{col.description}</div>
-          )}
-        </div>
-        <div onClick={e => e.stopPropagation()} className="relative">
-          {renamingId === col.id ? null : confirmingId === col.id ? (
-            <>
-              <button className="bg-delete-red border-none text-white cursor-pointer text-xs font-semibold px-1.5 py-0.5 rounded mr-0.5 whitespace-nowrap" aria-label="Confirm delete" onClick={e => handleConfirmDelete(e, col.id)}>Delete</button>
-              <button className="bg-transparent border border-border text-text-dim cursor-pointer text-xs px-1.5 py-0.5 rounded whitespace-nowrap" aria-label="Cancel" onClick={handleCancelDelete}>Cancel</button>
-            </>
-          ) : menuOpenId === col.id ? (
-            <div className="flex gap-1">
-              <button className="bg-transparent border border-border text-text text-xs px-2 py-1 rounded cursor-pointer hover:bg-surface-2" onClick={() => { setMenuOpenId(null); setRenamingId(col.id); setRenameValue(col.name) }}>Rename</button>
-              <button className="bg-transparent border border-border text-delete-red text-xs px-2 py-1 rounded cursor-pointer hover:bg-surface-2" onClick={e => { setMenuOpenId(null); handleDeleteClick(e, col.id) }}>Delete</button>
-            </div>
-          ) : (
-            <button className="bg-transparent border-none text-text-dim cursor-pointer text-lg p-1.5 rounded opacity-0 group-hover:opacity-50 hover:!opacity-100 hover:bg-surface-2 transition-opacity duration-150" aria-label="More options" onClick={() => setMenuOpenId(col.id)}>⋯</button>
-          )}
-        </div>
-      </div>
-      <div style={{ height: 62 }}>
-        <AlbumArtStrip albums={artAlbums} size={62} />
-      </div>
-    </div>
-  )
-}
-
-function SortableCollectionRow({ col, ...rest }) {
-  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: col.id })
-  const style = { transform: CSS.Transform.toString(transform), transition }
-  return (
-    <CollectionRow
-      col={col}
-      sortableRef={setNodeRef}
-      sortableStyle={style}
-      dragHandleProps={{ ...attributes, ...listeners }}
-      {...rest}
-    />
-  )
-}
 
 // Shared filter helper: returns the subset of `collections` that match the
 // currently-selected tag (or all when selectedTagId is null). A collection
@@ -131,11 +38,6 @@ export default function CollectionsPane({
   onBulkAdd,
   onCreateCollection,
   onReorder,
-  showCreate,
-  onShowCreateChange,
-  createName,
-  onCreateNameChange,
-  onCreateSubmit,
   // New props (Task 12)
   tags,
   selectedTagId,
@@ -148,13 +50,9 @@ export default function CollectionsPane({
 }) {
   const isMobile = useIsMobile()
   const [artMap, setArtMap] = useState({})
-  const [confirmingId, setConfirmingId] = useState(null)
-  const [menuOpenId, setMenuOpenId] = useState(null)
-  const [renamingId, setRenamingId] = useState(null)
-  const [renameValue, setRenameValue] = useState('')
 
   // Eagerly load album art previews per collection. Used by both the mobile
-  // legacy rows and the desktop grid/list (which take `albumsByCollection`).
+  // TagDrillPage and the desktop grid/list (which take `albumsByCollection`).
   useEffect(() => {
     if (!onFetchAlbums || !collections.length) return
     collections.forEach(col => {
@@ -166,55 +64,8 @@ export default function CollectionsPane({
     })
   }, [collections])  // eslint-disable-line react-hooks/exhaustive-deps
 
-  useEffect(() => {
-    if (!confirmingId && !menuOpenId) return
-    function handleDocClick() {
-      setConfirmingId(null)
-      setMenuOpenId(null)
-    }
-    const id = setTimeout(() => {
-      document.addEventListener('click', handleDocClick)
-    }, 0)
-    return () => {
-      clearTimeout(id)
-      document.removeEventListener('click', handleDocClick)
-    }
-  }, [confirmingId, menuOpenId])
-
-  function handleDeleteClick(e, colId) {
-    e.stopPropagation()
-    if (confirmingId !== colId) setConfirmingId(colId)
-  }
-  function handleConfirmDelete(e, colId) {
-    e.stopPropagation()
-    onDelete(colId)
-    setConfirmingId(null)
-  }
-  function handleCancelDelete(e) {
-    e.stopPropagation()
-    setConfirmingId(null)
-  }
-  function submitRename(col) {
-    const trimmed = renameValue.trim()
-    if (trimmed && trimmed !== col.name) {
-      onRename(col.id, trimmed)
-    }
-    setRenamingId(null)
-  }
-
-  const sensors = useSensors(useSensor(PointerSensor), useSensor(KeyboardSensor))
-  const sortableIds = useMemo(() => collections.map(c => c.id), [collections])
-  function handleDragEnd(event) {
-    const { active, over } = event
-    if (!over || active.id === over.id) return
-    const oldIndex = sortableIds.indexOf(active.id)
-    const newIndex = sortableIds.indexOf(over.id)
-    const newOrder = arrayMove(sortableIds, oldIndex, newIndex)
-    onReorder?.(newOrder)
-  }
-
   // albumsByCollection: { [collectionId]: Album[] } derived from the artMap
-  // used for both mobile rows (legacy) and desktop grid/list previews.
+  // used for both mobile TagDrillPage and desktop grid/list previews.
   const albumsByCollection = useMemo(() => {
     const out = {}
     Object.entries(artMap).forEach(([colId, entry]) => {
@@ -261,6 +112,7 @@ export default function CollectionsPane({
         currentTagId={selectedTagId ?? null}
         onSelectTag={onSelectTag || (() => {})}
         onOpenCollection={onEnter}
+        onCreateCollection={onCreateCollection}
         servingPlatter={servingPlatter}
       />
     )

--- a/frontend/src/components/CollectionsPane.test.jsx
+++ b/frontend/src/components/CollectionsPane.test.jsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import CollectionsPane from './CollectionsPane'
+import CollectionsPane, { filterCollectionsByTag } from './CollectionsPane'
 import { useIsMobile } from '../hooks/useIsMobile'
 
 // Mock apiFetch so AlbumPromptBar's home-data fetch doesn't fail
@@ -14,12 +14,9 @@ vi.mock('../hooks/useIsMobile', () => ({
   useIsMobile: vi.fn().mockReturnValue(false),
 }))
 
-const TWO_DAYS_AGO = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString()
-const FIVE_DAYS_AGO = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString()
-
 const COLLECTIONS = [
-  { id: 'col-1', name: 'Road trip', album_count: 5, updated_at: TWO_DAYS_AGO },
-  { id: 'col-2', name: '90s classics', album_count: 12, updated_at: FIVE_DAYS_AGO },
+  { id: 'col-1', name: 'Road trip', album_count: 5 },
+  { id: 'col-2', name: '90s classics', album_count: 12 },
 ]
 
 const ALBUMS = [
@@ -27,483 +24,181 @@ const ALBUMS = [
   { service_id: 'alb-2', name: 'OK Computer', artists: ['Radiohead'], image_url: null },
 ]
 
-describe('CollectionsPane', () => {
+const TAGS = [
+  { id: 'tag-root', name: 'Mood', parent_tag_id: null, position: 0 },
+  { id: 'tag-child', name: 'Chill', parent_tag_id: 'tag-root', position: 0 },
+  { id: 'tag-other', name: 'Genre', parent_tag_id: null, position: 1 },
+]
+
+const baseDesktopProps = {
+  collections: COLLECTIONS,
+  onEnter: vi.fn(),
+  onDelete: vi.fn(),
+  onRename: vi.fn(),
+  onCreate: vi.fn(),
+  onFetchAlbums: () => Promise.resolve([]),
+  tags: [],
+  selectedTagId: null,
+  onSelectTag: vi.fn(),
+  viewMode: 'list',
+  onViewModeChange: vi.fn(),
+  onManageTags: vi.fn(),
+  onOpenTagManager: vi.fn(),
+  collectionTagsMap: {},
+}
+
+describe('CollectionsPane (desktop) — list view rendering', () => {
   it('renders all collection names', () => {
-    render(
-      <CollectionsPane
-        collections={COLLECTIONS}
-        onEnter={() => {}}
-        onDelete={() => {}}
-        onFetchAlbums={() => Promise.resolve([])}
-      />
-    )
+    render(<CollectionsPane {...baseDesktopProps} />)
     expect(screen.getByText('Road trip')).toBeInTheDocument()
     expect(screen.getByText('90s classics')).toBeInTheDocument()
   })
 
   it('shows empty state when no collections', () => {
-    render(
-      <CollectionsPane
-        collections={[]}
-        onEnter={() => {}}
-        onDelete={() => {}}
-        onFetchAlbums={() => Promise.resolve([])}
-      />
-    )
+    render(<CollectionsPane {...baseDesktopProps} collections={[]} />)
     expect(screen.getByText(/no collections/i)).toBeInTheDocument()
   })
 
-  it('calls onEnter with collection when collection row is clicked', async () => {
+  it('calls onEnter with collection when row is clicked', async () => {
     const onEnter = vi.fn()
-    render(
-      <CollectionsPane
-        collections={COLLECTIONS}
-        onEnter={onEnter}
-        onDelete={() => {}}
-        onFetchAlbums={() => Promise.resolve([])}
-      />
-    )
+    render(<CollectionsPane {...baseDesktopProps} onEnter={onEnter} />)
     await userEvent.click(screen.getByText('Road trip'))
     expect(onEnter).toHaveBeenCalledWith(COLLECTIONS[0])
   })
 
-  it('calls onDelete with collection id when Delete is confirmed (three-click flow)', async () => {
-    const onDelete = vi.fn()
-    render(
-      <CollectionsPane
-        collections={COLLECTIONS}
-        onEnter={() => {}}
-        onDelete={onDelete}
-        onRename={() => {}}
-        onFetchAlbums={() => Promise.resolve([])}
-      />
-    )
-    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
-    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }))
-    await userEvent.click(screen.getByRole('button', { name: /confirm delete/i }))
-    expect(onDelete).toHaveBeenCalledWith('col-1')
-  })
-
-  it('does not call onEnter when the menu button is clicked', async () => {
-    const onEnter = vi.fn()
-    render(
-      <CollectionsPane
-        collections={COLLECTIONS}
-        onEnter={onEnter}
-        onDelete={() => {}}
-        onRename={() => {}}
-        onFetchAlbums={() => Promise.resolve([])}
-      />
-    )
-    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
-    expect(onEnter).not.toHaveBeenCalled()
-  })
-
-  it('does not render expand arrow buttons', () => {
-    render(
-      <CollectionsPane
-        collections={COLLECTIONS}
-        onEnter={() => {}}
-        onDelete={() => {}}
-        onFetchAlbums={() => Promise.resolve([])}
-      />
-    )
-    expect(screen.queryByRole('button', { name: /expand/i })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /collapse/i })).not.toBeInTheDocument()
-  })
-
-  it('does not show inline album list by default', () => {
-    render(
-      <CollectionsPane
-        collections={COLLECTIONS}
-        onEnter={() => {}}
-        onDelete={() => {}}
-        onFetchAlbums={() => Promise.resolve([])}
-      />
-    )
-    expect(screen.queryByText('In Rainbows')).not.toBeInTheDocument()
-  })
-
-  it('fetches albums for each collection on mount and shows art thumbnails', async () => {
+  it('fetches albums for each collection on mount (powers thumbnails)', async () => {
     const onFetchAlbums = vi.fn().mockResolvedValue(ALBUMS)
-    render(
-      <CollectionsPane
-        collections={COLLECTIONS}
-        onEnter={() => {}}
-        onDelete={() => {}}
-        onFetchAlbums={onFetchAlbums}
-      />
-    )
+    render(<CollectionsPane {...baseDesktopProps} onFetchAlbums={onFetchAlbums} />)
     await waitFor(() => {
       expect(onFetchAlbums).toHaveBeenCalledWith('col-1')
       expect(onFetchAlbums).toHaveBeenCalledWith('col-2')
     })
   })
 
-  it('shows album art thumbnails in each collection row once loaded', async () => {
-    const onFetchAlbums = vi.fn().mockResolvedValue(ALBUMS)
-    render(
-      <CollectionsPane
-        collections={[COLLECTIONS[0]]}
-        onEnter={() => {}}
-        onDelete={() => {}}
-        onFetchAlbums={onFetchAlbums}
-      />
-    )
-    await waitFor(() => {
-      const img = screen.getByAltText('In Rainbows')
-      expect(img).toBeInTheDocument()
-      expect(img).toHaveAttribute('src', 'http://img/1.jpg')
-    })
+  it('does not show inline album list by default', () => {
+    render(<CollectionsPane {...baseDesktopProps} />)
+    expect(screen.queryByText('In Rainbows')).not.toBeInTheDocument()
   })
 
-  it('renders AlbumArtStrip with 40px thumbnails for each collection', async () => {
-    const albums = [
-      { service_id: 'alb-1', name: 'In Rainbows', image_url: 'http://img/1.jpg' },
-    ]
-    const onFetchAlbums = vi.fn().mockResolvedValue(albums)
-    render(
-      <CollectionsPane
-        collections={[COLLECTIONS[0]]}
-        onEnter={() => {}}
-        onDelete={() => {}}
-        onFetchAlbums={onFetchAlbums}
-      />
-    )
-    await waitFor(() => {
-      const img = screen.getByAltText('In Rainbows')
-      expect(img).toBeInTheDocument()
-      expect(img).toHaveAttribute('width', '62')
-    })
+  it('renders + New Collection button which fires onCreate', async () => {
+    const onCreate = vi.fn()
+    render(<CollectionsPane {...baseDesktopProps} onCreate={onCreate} />)
+    const btn = screen.getByRole('button', { name: /new collection/i })
+    await userEvent.click(btn)
+    expect(onCreate).toHaveBeenCalled()
   })
 
-  it('shows album count badge', () => {
-    render(
-      <CollectionsPane
-        collections={COLLECTIONS}
-        onEnter={() => {}}
-        onDelete={() => {}}
-        onFetchAlbums={() => Promise.resolve([])}
-      />
-    )
-    expect(screen.getByText('5 albums')).toBeInTheDocument()
-    expect(screen.getByText('12 albums')).toBeInTheDocument()
-  })
-
-  it('shows description as subtitle on collection card', () => {
-    const cols = [{ id: '1', name: 'Late Night', album_count: 5, description: 'low energy, headphone albums' }]
-    render(<CollectionsPane collections={cols} onEnter={() => {}} onDelete={() => {}} onCreate={() => {}} onFetchAlbums={vi.fn().mockResolvedValue([])} />)
-    expect(screen.getByText('low energy, headphone albums')).toBeInTheDocument()
-  })
-
-  it('does not show description when null', () => {
-    const cols = [{ id: '1', name: 'Late Night', album_count: 5, description: null }]
-    render(<CollectionsPane collections={cols} onEnter={() => {}} onDelete={() => {}} onCreate={() => {}} onFetchAlbums={vi.fn().mockResolvedValue([])} />)
-    expect(screen.queryByText('low energy')).not.toBeInTheDocument()
-  })
-
-  it('does not render a create input or Create button', () => {
-    render(
-      <CollectionsPane
-        collections={[]}
-        onEnter={() => {}}
-        onDelete={() => {}}
-        onCreate={() => {}}
-        onFetchAlbums={() => Promise.resolve([])}
-      />
-    )
-    expect(screen.queryByPlaceholderText(/new collection/i)).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /create/i })).not.toBeInTheDocument()
-  })
-
-  it('art strip container has fixed height to prevent layout shift', () => {
-    render(
-      <CollectionsPane
-        collections={COLLECTIONS}
-        onEnter={() => {}}
-        onDelete={() => {}}
-        onFetchAlbums={() => Promise.resolve([])}
-      />
-    )
-    const firstRow = screen.getByText('Road trip').closest('[data-testid="collection-row"]')
-    // The inner layout container (desktop: flex row, mobile: strip wrapper) has a fixed height
-    const fixedHeightEl = firstRow.querySelector('[style*="height: 62px"], [style*="height:62px"]')
-    expect(fixedHeightEl).toBeInTheDocument()
-  })
-
-  it('always renders album art strip area even before albums load', () => {
-    render(
-      <CollectionsPane
-        collections={COLLECTIONS}
-        onEnter={() => {}}
-        onDelete={() => {}}
-        onFetchAlbums={() => Promise.resolve([])}
-      />
-    )
-    // Strip container should exist immediately (not conditionally rendered)
-    const firstRow = screen.getByText('Road trip').closest('[data-testid="collection-row"]')
-    const fixedHeightEl = firstRow.querySelector('[style*="height: 62px"], [style*="height:62px"]')
-    expect(fixedHeightEl).toBeInTheDocument()
-  })
-
-  it('collections list container allows vertical scrolling', () => {
-    render(
-      <CollectionsPane
-        collections={COLLECTIONS}
-        onEnter={() => {}}
-        onDelete={() => {}}
-        onFetchAlbums={() => Promise.resolve([])}
-      />
-    )
-    const firstRow = screen.getByText('Road trip').closest('[data-testid="collection-row"]')
-    const listContainer = firstRow.parentElement
-    expect(listContainer.className).toContain('overflow-y-auto')
-    expect(listContainer.className).not.toContain('overflow-hidden')
-  })
-
-  it('does not use a multi-column grid layout', () => {
-    render(
-      <CollectionsPane
-        collections={COLLECTIONS}
-        onEnter={() => {}}
-        onDelete={() => {}}
-        onFetchAlbums={() => Promise.resolve([])}
-      />
-    )
-    const gridEl = document.querySelector('.grid')
-    expect(gridEl).not.toBeInTheDocument()
-  })
-
-  // --- Three-dot menu ---
-
-  it('shows a three-dot menu button on each collection row', () => {
-    render(
-      <CollectionsPane
-        collections={COLLECTIONS}
-        onEnter={() => {}}
-        onDelete={() => {}}
-        onRename={() => {}}
-        onFetchAlbums={() => Promise.resolve([])}
-      />
-    )
-    const menuBtns = screen.getAllByRole('button', { name: /more options/i })
-    expect(menuBtns).toHaveLength(2)
-  })
-
-  it('opens menu with Rename and Delete options on click', async () => {
-    render(
-      <CollectionsPane
-        collections={COLLECTIONS}
-        onEnter={() => {}}
-        onDelete={() => {}}
-        onRename={() => {}}
-        onFetchAlbums={() => Promise.resolve([])}
-      />
-    )
-    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
-    expect(screen.getByRole('button', { name: /^rename$/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument()
-  })
-
-  it('enters inline rename mode when Rename is clicked from menu', async () => {
-    render(
-      <CollectionsPane
-        collections={COLLECTIONS}
-        onEnter={() => {}}
-        onDelete={() => {}}
-        onRename={() => {}}
-        onFetchAlbums={() => Promise.resolve([])}
-      />
-    )
-    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
-    await userEvent.click(screen.getByRole('button', { name: /^rename$/i }))
-    expect(screen.getByDisplayValue('Road trip')).toBeInTheDocument()
-  })
-
-  it('calls onRename with new name on Enter', async () => {
-    const onRename = vi.fn()
-    render(
-      <CollectionsPane
-        collections={COLLECTIONS}
-        onEnter={() => {}}
-        onDelete={() => {}}
-        onRename={onRename}
-        onFetchAlbums={() => Promise.resolve([])}
-      />
-    )
-    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
-    await userEvent.click(screen.getByRole('button', { name: /^rename$/i }))
-    const input = screen.getByDisplayValue('Road trip')
-    await userEvent.clear(input)
-    await userEvent.type(input, 'Summer vibes{Enter}')
-    expect(onRename).toHaveBeenCalledWith('col-1', 'Summer vibes')
-  })
-
-  it('cancels rename on Escape without calling onRename', async () => {
-    const onRename = vi.fn()
-    render(
-      <CollectionsPane
-        collections={COLLECTIONS}
-        onEnter={() => {}}
-        onDelete={() => {}}
-        onRename={onRename}
-        onFetchAlbums={() => Promise.resolve([])}
-      />
-    )
-    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
-    await userEvent.click(screen.getByRole('button', { name: /^rename$/i }))
-    await userEvent.keyboard('{Escape}')
-    expect(onRename).not.toHaveBeenCalled()
-    expect(screen.getByText('Road trip')).toBeInTheDocument()
-  })
-
-  it('does not call onRename if name is unchanged', async () => {
-    const onRename = vi.fn()
-    render(
-      <CollectionsPane
-        collections={COLLECTIONS}
-        onEnter={() => {}}
-        onDelete={() => {}}
-        onRename={onRename}
-        onFetchAlbums={() => Promise.resolve([])}
-      />
-    )
-    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
-    await userEvent.click(screen.getByRole('button', { name: /^rename$/i }))
-    await userEvent.keyboard('{Enter}')
-    expect(onRename).not.toHaveBeenCalled()
-  })
-
-  it('does not call onRename if name is empty', async () => {
-    const onRename = vi.fn()
-    render(
-      <CollectionsPane
-        collections={COLLECTIONS}
-        onEnter={() => {}}
-        onDelete={() => {}}
-        onRename={onRename}
-        onFetchAlbums={() => Promise.resolve([])}
-      />
-    )
-    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
-    await userEvent.click(screen.getByRole('button', { name: /^rename$/i }))
-    const input = screen.getByDisplayValue('Road trip')
-    await userEvent.clear(input)
-    await userEvent.keyboard('{Enter}')
-    expect(onRename).not.toHaveBeenCalled()
-  })
-
-  // --- Delete confirmation ---
-
-  it('delete button shows confirmation via menu', async () => {
-    render(
-      <CollectionsPane
-        collections={COLLECTIONS}
-        onEnter={() => {}}
-        onDelete={() => {}}
-        onRename={() => {}}
-        onFetchAlbums={() => Promise.resolve([])}
-      />
-    )
-    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
-    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }))
-    expect(screen.getByRole('button', { name: /confirm delete/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
-  })
-
-  it('confirm delete calls onDelete', async () => {
-    const onDelete = vi.fn()
-    render(
-      <CollectionsPane
-        collections={COLLECTIONS}
-        onEnter={() => {}}
-        onDelete={onDelete}
-        onRename={() => {}}
-        onFetchAlbums={() => Promise.resolve([])}
-      />
-    )
-    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
-    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }))
-    const confirmBtn = screen.getByRole('button', { name: /confirm delete/i })
-    await userEvent.click(confirmBtn)
-    expect(onDelete).toHaveBeenCalledWith('col-1')
-  })
-
-  it('cancel delete does not call onDelete', async () => {
-    const onDelete = vi.fn()
-    render(
-      <CollectionsPane
-        collections={COLLECTIONS}
-        onEnter={() => {}}
-        onDelete={onDelete}
-        onRename={() => {}}
-        onFetchAlbums={() => Promise.resolve([])}
-      />
-    )
-    await userEvent.click(screen.getAllByRole('button', { name: /more options/i })[0])
-    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }))
-    const cancelBtn = screen.getByRole('button', { name: /cancel/i })
-    await userEvent.click(cancelBtn)
-    expect(onDelete).not.toHaveBeenCalled()
-  })
-
-  // --- Drag reorder ---
-
-  it('renders drag handles when onReorder prop is provided', () => {
-    render(
-      <CollectionsPane
-        collections={COLLECTIONS}
-        onEnter={() => {}}
-        onDelete={() => {}}
-        onFetchAlbums={() => Promise.resolve([])}
-        onReorder={() => {}}
-      />
-    )
-    const handles = screen.getAllByRole('button', { name: /drag to reorder/i })
-    expect(handles).toHaveLength(2)
-  })
-
-  it('does not render drag handles when onReorder is not provided', () => {
-    render(
-      <CollectionsPane
-        collections={COLLECTIONS}
-        onEnter={() => {}}
-        onDelete={() => {}}
-        onFetchAlbums={() => Promise.resolve([])}
-      />
-    )
-    expect(screen.queryByRole('button', { name: /drag to reorder/i })).not.toBeInTheDocument()
-  })
-
-  it('renders AlbumPromptBar when prompt bar props are provided', async () => {
-    const { apiFetch } = await import('../api')
-    apiFetch.mockResolvedValue({
-      json: () => Promise.resolve({
-        recently_added: [{ service_id: 'ra1', name: 'New Album', image_url: 'https://example.com/new.jpg' }],
-        recently_played: [],
-      }),
-    })
-    render(
-      <CollectionsPane
-        collections={[]}
-        onEnter={() => {}}
-        onDelete={() => {}}
-        onCreate={() => {}}
-        onFetchAlbums={() => Promise.resolve([])}
-        albumCollectionMap={{}}
-        collectionsForPicker={[]}
-        session={{ access_token: 'test' }}
-        onBulkAdd={() => {}}
-        onCreateCollection={() => {}}
-      />
-    )
+  it('renders the AlbumPromptBar', async () => {
+    render(<CollectionsPane {...baseDesktopProps} session={{ access_token: 't' }} />)
     await waitFor(() => {
       expect(screen.getByTestId('album-prompt-bar')).toBeInTheDocument()
     })
   })
+
+  it('renders the TagTreeSidebar with All entry', () => {
+    render(<CollectionsPane {...baseDesktopProps} />)
+    expect(screen.getByText('All')).toBeInTheDocument()
+  })
 })
 
-describe('CollectionsPane inline create (mobile)', () => {
+describe('CollectionsPane (desktop) — view toggle', () => {
+  it('renders CollectionList rows when viewMode is list', () => {
+    render(<CollectionsPane {...baseDesktopProps} viewMode="list" />)
+    const rows = screen.getAllByTestId('collection-list-row')
+    expect(rows).toHaveLength(2)
+  })
+
+  it('switches to grid when viewMode is grid', () => {
+    render(<CollectionsPane {...baseDesktopProps} viewMode="grid" />)
+    // Grid view renders no list rows.
+    expect(screen.queryByTestId('collection-list-row')).not.toBeInTheDocument()
+    // Names still visible (rendered as cards instead).
+    expect(screen.getByText('Road trip')).toBeInTheDocument()
+    expect(screen.getByText('90s classics')).toBeInTheDocument()
+  })
+
+  it('clicking grid icon in toggle calls onViewModeChange("grid")', async () => {
+    const onViewModeChange = vi.fn()
+    render(<CollectionsPane {...baseDesktopProps} viewMode="list" onViewModeChange={onViewModeChange} />)
+    await userEvent.click(screen.getByRole('button', { name: /grid view/i }))
+    expect(onViewModeChange).toHaveBeenCalledWith('grid')
+  })
+})
+
+describe('CollectionsPane (desktop) — tag filtering', () => {
+  const filteredProps = {
+    ...baseDesktopProps,
+    tags: TAGS,
+    collections: [
+      { id: 'col-1', name: 'Road trip', album_count: 5 },
+      { id: 'col-2', name: 'Chill nights', album_count: 7 },
+      { id: 'col-3', name: 'Untagged', album_count: 3 },
+    ],
+    collectionTagsMap: {
+      'col-1': ['tag-other'],
+      'col-2': ['tag-child'],
+      // col-3 has no tags
+    },
+  }
+
+  it('shows all collections when selectedTagId is null', () => {
+    render(<CollectionsPane {...filteredProps} selectedTagId={null} />)
+    expect(screen.getByText('Road trip')).toBeInTheDocument()
+    expect(screen.getByText('Chill nights')).toBeInTheDocument()
+    expect(screen.getByText('Untagged')).toBeInTheDocument()
+  })
+
+  it('narrows to collections directly tagged with the selected tag', () => {
+    render(<CollectionsPane {...filteredProps} selectedTagId="tag-other" />)
+    expect(screen.getByText('Road trip')).toBeInTheDocument()
+    expect(screen.queryByText('Chill nights')).not.toBeInTheDocument()
+    expect(screen.queryByText('Untagged')).not.toBeInTheDocument()
+  })
+
+  it('includes descendants when a parent tag is selected', () => {
+    // Selecting parent "Mood" should include collections tagged with "Chill"
+    render(<CollectionsPane {...filteredProps} selectedTagId="tag-root" />)
+    expect(screen.getByText('Chill nights')).toBeInTheDocument()
+    expect(screen.queryByText('Road trip')).not.toBeInTheDocument()
+  })
+})
+
+describe('filterCollectionsByTag (pure helper)', () => {
+  it('returns all collections when selectedTagId is null', () => {
+    const result = filterCollectionsByTag(
+      [{ id: 'a' }, { id: 'b' }],
+      [],
+      null,
+      {},
+    )
+    expect(result).toHaveLength(2)
+  })
+
+  it('returns only collections matching the selected tag', () => {
+    const result = filterCollectionsByTag(
+      [{ id: 'a' }, { id: 'b' }],
+      [{ id: 't1', name: 'X', parent_tag_id: null, position: 0 }],
+      't1',
+      { a: ['t1'], b: [] },
+    )
+    expect(result).toEqual([{ id: 'a' }])
+  })
+
+  it('returns descendants when a parent tag is selected', () => {
+    const result = filterCollectionsByTag(
+      [{ id: 'a' }, { id: 'b' }],
+      [
+        { id: 't1', name: 'P', parent_tag_id: null, position: 0 },
+        { id: 't2', name: 'C', parent_tag_id: 't1', position: 0 },
+      ],
+      't1',
+      { a: ['t2'], b: [] },
+    )
+    expect(result).toEqual([{ id: 'a' }])
+  })
+})
+
+describe('CollectionsPane mobile (legacy)', () => {
   beforeEach(() => {
     useIsMobile.mockReturnValue(true)
   })
@@ -511,13 +206,13 @@ describe('CollectionsPane inline create (mobile)', () => {
     useIsMobile.mockReturnValue(false)
   })
 
-  const baseProps = {
+  const mobileProps = {
     collections: [],
     onEnter: vi.fn(),
     onDelete: vi.fn(),
     onCreate: vi.fn(),
     onRename: vi.fn(),
-    onFetchAlbums: vi.fn(),
+    onFetchAlbums: vi.fn().mockResolvedValue([]),
     albumCollectionMap: {},
     collectionsForPicker: [],
     session: { access_token: 'test' },
@@ -532,19 +227,22 @@ describe('CollectionsPane inline create (mobile)', () => {
   }
 
   it('renders create collection button when showCreate is false', () => {
-    render(<CollectionsPane {...baseProps} />)
+    render(<CollectionsPane {...mobileProps} />)
     expect(screen.getByLabelText('Create collection')).toBeInTheDocument()
   })
 
   it('renders name input when showCreate is true', () => {
-    render(<CollectionsPane {...baseProps} showCreate={true} />)
+    render(<CollectionsPane {...mobileProps} showCreate={true} />)
     expect(screen.getByPlaceholderText(/collection name/i)).toBeInTheDocument()
   })
 
-  it('calls onShowCreateChange when create button clicked', async () => {
-    const onShowCreateChange = vi.fn()
-    render(<CollectionsPane {...baseProps} onShowCreateChange={onShowCreateChange} />)
-    await userEvent.click(screen.getByLabelText('Create collection'))
-    expect(onShowCreateChange).toHaveBeenCalledWith(true)
+  it('renders mobile rows with collection-row testid', () => {
+    render(<CollectionsPane {...mobileProps} collections={COLLECTIONS} />)
+    expect(screen.getAllByTestId('collection-row')).toHaveLength(2)
+  })
+
+  it('does not render the desktop tag sidebar on mobile', () => {
+    render(<CollectionsPane {...mobileProps} collections={COLLECTIONS} />)
+    expect(screen.queryByText('All')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/CollectionsPane.test.jsx
+++ b/frontend/src/components/CollectionsPane.test.jsx
@@ -198,7 +198,7 @@ describe('filterCollectionsByTag (pure helper)', () => {
   })
 })
 
-describe('CollectionsPane mobile (legacy)', () => {
+describe('CollectionsPane mobile (drill-down)', () => {
   beforeEach(() => {
     useIsMobile.mockReturnValue(true)
   })
@@ -207,7 +207,7 @@ describe('CollectionsPane mobile (legacy)', () => {
   })
 
   const mobileProps = {
-    collections: [],
+    collections: COLLECTIONS,
     onEnter: vi.fn(),
     onDelete: vi.fn(),
     onCreate: vi.fn(),
@@ -219,30 +219,36 @@ describe('CollectionsPane mobile (legacy)', () => {
     onBulkAdd: vi.fn(),
     onCreateCollection: vi.fn(),
     onReorder: null,
-    showCreate: false,
-    onShowCreateChange: vi.fn(),
-    createName: '',
-    onCreateNameChange: vi.fn(),
-    onCreateSubmit: vi.fn(),
+    tags: TAGS,
+    selectedTagId: null,
+    onSelectTag: vi.fn(),
+    collectionTagsMap: {},
   }
 
-  it('renders create collection button when showCreate is false', () => {
+  it('renders Collections header at root', () => {
     render(<CollectionsPane {...mobileProps} />)
-    expect(screen.getByLabelText('Create collection')).toBeInTheDocument()
+    expect(screen.getByText('Collections')).toBeInTheDocument()
   })
 
-  it('renders name input when showCreate is true', () => {
-    render(<CollectionsPane {...mobileProps} showCreate={true} />)
-    expect(screen.getByPlaceholderText(/collection name/i)).toBeInTheDocument()
+  it('renders root tag rows', () => {
+    render(<CollectionsPane {...mobileProps} />)
+    expect(screen.getByText('Mood')).toBeInTheDocument()
+    expect(screen.getByText('Genre')).toBeInTheDocument()
   })
 
-  it('renders mobile rows with collection-row testid', () => {
-    render(<CollectionsPane {...mobileProps} collections={COLLECTIONS} />)
-    expect(screen.getAllByTestId('collection-row')).toHaveLength(2)
+  it('renders all collections at root', () => {
+    render(<CollectionsPane {...mobileProps} />)
+    expect(screen.getByText('Road trip')).toBeInTheDocument()
+    expect(screen.getByText('90s classics')).toBeInTheDocument()
   })
 
   it('does not render the desktop tag sidebar on mobile', () => {
-    render(<CollectionsPane {...mobileProps} collections={COLLECTIONS} />)
+    render(<CollectionsPane {...mobileProps} />)
     expect(screen.queryByText('All')).not.toBeInTheDocument()
+  })
+
+  it('shows back button when inside a tag', () => {
+    render(<CollectionsPane {...mobileProps} selectedTagId="tag-root" />)
+    expect(screen.getByLabelText(/back/i)).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/TagDrillPage.jsx
+++ b/frontend/src/components/TagDrillPage.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import CollectionGrid from './CollectionGrid'
 import { buildTagTree, findNode, getDescendantIds } from '../lib/tagTree'
 
@@ -13,8 +13,11 @@ export default function TagDrillPage({
   currentTagId,
   onSelectTag,
   onOpenCollection,
+  onCreateCollection,
   servingPlatter,
 }) {
+  const [showCreate, setShowCreate] = useState(false)
+  const [createName, setCreateName] = useState('')
   const tree = useMemo(() => buildTagTree(tags || []), [tags])
   const currentNode = useMemo(
     () => (currentTagId ? findNode(tree, currentTagId) : null),
@@ -48,7 +51,45 @@ export default function TagDrillPage({
     <div className="w-full flex flex-col h-full overflow-hidden">
       <div className="flex items-center px-4 py-3 border-b border-border flex-shrink-0 gap-2">
         {isRoot ? (
-          <h1 className="text-base font-semibold text-text">Collections</h1>
+          <>
+            <h1 className="text-base font-semibold text-text">Collections</h1>
+            {onCreateCollection && (
+              <div className="ml-auto">
+                {showCreate ? (
+                  <input
+                    autoFocus
+                    className="bg-surface-2 text-text border border-border rounded-full px-3 py-1 text-sm w-48"
+                    placeholder="Collection name…"
+                    value={createName}
+                    onChange={(e) => setCreateName(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        const trimmed = createName.trim()
+                        if (trimmed) onCreateCollection(trimmed)
+                        setCreateName('')
+                        setShowCreate(false)
+                      } else if (e.key === 'Escape') {
+                        setCreateName('')
+                        setShowCreate(false)
+                      }
+                    }}
+                    onBlur={() => {
+                      setCreateName('')
+                      setShowCreate(false)
+                    }}
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setShowCreate(true)}
+                    className="bg-transparent border border-border text-text text-xs px-3 py-1 rounded cursor-pointer hover:bg-bg-elevated"
+                  >
+                    + New Collection
+                  </button>
+                )}
+              </div>
+            )}
+          </>
         ) : (
           <>
             <button

--- a/frontend/src/components/TagDrillPage.jsx
+++ b/frontend/src/components/TagDrillPage.jsx
@@ -1,0 +1,102 @@
+import { useMemo } from 'react'
+import CollectionGrid from './CollectionGrid'
+import { buildTagTree, findNode, getDescendantIds } from '../lib/tagTree'
+
+// Mobile drill-down navigation for tags + collections.
+// - Root view (currentTagId === null): list of root tags + all collections grid + servingPlatter
+// - Tag view (currentTagId !== null): back button, child tags, collections under this tag/descendants
+export default function TagDrillPage({
+  tags,
+  collections,
+  collectionTagsMap,
+  albumsByCollection,
+  currentTagId,
+  onSelectTag,
+  onOpenCollection,
+  servingPlatter,
+}) {
+  const tree = useMemo(() => buildTagTree(tags || []), [tags])
+  const currentNode = useMemo(
+    () => (currentTagId ? findNode(tree, currentTagId) : null),
+    [tree, currentTagId],
+  )
+
+  const isRoot = currentTagId == null
+
+  const childTags = isRoot ? tree : currentNode?.children || []
+
+  const visibleCollections = useMemo(() => {
+    if (isRoot) return collections
+    if (!currentNode) return []
+    const allowed = getDescendantIds(tree, currentTagId)
+    if (allowed.size === 0) return []
+    return collections.filter((c) => {
+      const tagIds = (collectionTagsMap || {})[c.id] || []
+      return tagIds.some((id) => allowed.has(id))
+    })
+  }, [isRoot, currentNode, tree, currentTagId, collections, collectionTagsMap])
+
+  function handleBack() {
+    if (!currentNode) {
+      onSelectTag(null)
+      return
+    }
+    onSelectTag(currentNode.parent_tag_id || null)
+  }
+
+  return (
+    <div className="w-full flex flex-col h-full overflow-hidden">
+      <div className="flex items-center px-4 py-3 border-b border-border flex-shrink-0 gap-2">
+        {isRoot ? (
+          <h1 className="text-base font-semibold text-text">Collections</h1>
+        ) : (
+          <>
+            <button
+              type="button"
+              aria-label="Back"
+              onClick={handleBack}
+              className="bg-transparent border-none text-text-dim hover:text-text cursor-pointer p-1 rounded"
+            >
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <path d="M15 18l-6-6 6-6" />
+              </svg>
+            </button>
+            <h1 className="text-base font-semibold text-text truncate">{currentNode?.name}</h1>
+          </>
+        )}
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {childTags.length > 0 && (
+          <div className="border-b border-border">
+            {childTags.map((node) => (
+              <button
+                key={node.id}
+                type="button"
+                onClick={() => onSelectTag(node.id)}
+                className="w-full flex items-center justify-between px-4 py-3 bg-transparent border-none border-b border-border text-left cursor-pointer hover:bg-bg-elevated transition-colors duration-150"
+              >
+                <span className="text-sm text-text">{node.name}</span>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="text-text-dim">
+                  <path d="M9 18l6-6-6-6" />
+                </svg>
+              </button>
+            ))}
+          </div>
+        )}
+
+        {visibleCollections.length > 0 ? (
+          <CollectionGrid
+            collections={visibleCollections}
+            albumsByCollection={albumsByCollection || {}}
+            onOpen={onOpenCollection}
+          />
+        ) : !isRoot && childTags.length === 0 ? (
+          <div className="p-4 text-sm text-text-dim italic">No collections under this tag</div>
+        ) : null}
+
+        {isRoot && servingPlatter}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/TagDrillPage.test.jsx
+++ b/frontend/src/components/TagDrillPage.test.jsx
@@ -64,6 +64,43 @@ describe('TagDrillPage — root view', () => {
     await userEvent.click(screen.getByText('Mood'))
     expect(onSelectTag).toHaveBeenCalledWith('tag-mood')
   })
+
+  it('renders + New Collection trigger at root', () => {
+    render(<TagDrillPage {...baseProps} onCreateCollection={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /new collection/i })).toBeInTheDocument()
+  })
+
+  it('clicking + reveals input; Enter calls onCreateCollection with trimmed name', async () => {
+    const onCreateCollection = vi.fn()
+    render(<TagDrillPage {...baseProps} onCreateCollection={onCreateCollection} />)
+    await userEvent.click(screen.getByRole('button', { name: /new collection/i }))
+    const input = screen.getByPlaceholderText(/collection name/i)
+    await userEvent.type(input, '  Road Trip  {Enter}')
+    expect(onCreateCollection).toHaveBeenCalledWith('Road Trip')
+  })
+
+  it('Escape cancels the inline input without calling onCreateCollection', async () => {
+    const onCreateCollection = vi.fn()
+    render(<TagDrillPage {...baseProps} onCreateCollection={onCreateCollection} />)
+    await userEvent.click(screen.getByRole('button', { name: /new collection/i }))
+    const input = screen.getByPlaceholderText(/collection name/i)
+    await userEvent.type(input, 'Discard{Escape}')
+    expect(onCreateCollection).not.toHaveBeenCalled()
+    expect(screen.queryByPlaceholderText(/collection name/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('TagDrillPage — create affordance only at root', () => {
+  it('does NOT render + New Collection inside a tag view', () => {
+    render(
+      <TagDrillPage
+        {...baseProps}
+        currentTagId="tag-mood"
+        onCreateCollection={vi.fn()}
+      />,
+    )
+    expect(screen.queryByRole('button', { name: /new collection/i })).not.toBeInTheDocument()
+  })
 })
 
 describe('TagDrillPage — tag view', () => {

--- a/frontend/src/components/TagDrillPage.test.jsx
+++ b/frontend/src/components/TagDrillPage.test.jsx
@@ -1,0 +1,122 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import TagDrillPage from './TagDrillPage'
+
+const TAGS = [
+  { id: 'tag-mood', name: 'Mood', parent_tag_id: null, position: 0 },
+  { id: 'tag-chill', name: 'Chill', parent_tag_id: 'tag-mood', position: 0 },
+  { id: 'tag-hype', name: 'Hype', parent_tag_id: 'tag-mood', position: 1 },
+  { id: 'tag-genre', name: 'Genre', parent_tag_id: null, position: 1 },
+]
+
+const COLLECTIONS = [
+  { id: 'col-1', name: 'Road trip', album_count: 5 },
+  { id: 'col-2', name: 'Chill nights', album_count: 7 },
+  { id: 'col-3', name: 'Untagged', album_count: 3 },
+]
+
+const COLLECTION_TAGS_MAP = {
+  'col-1': ['tag-genre'],
+  'col-2': ['tag-chill'],
+  // col-3 has no tags
+}
+
+const baseProps = {
+  tags: TAGS,
+  collections: COLLECTIONS,
+  collectionTagsMap: COLLECTION_TAGS_MAP,
+  albumsByCollection: {},
+  currentTagId: null,
+  onSelectTag: vi.fn(),
+  onOpenCollection: vi.fn(),
+  servingPlatter: <div data-testid="serving-platter">platter</div>,
+}
+
+describe('TagDrillPage — root view', () => {
+  it('renders Collections header', () => {
+    render(<TagDrillPage {...baseProps} />)
+    expect(screen.getByText('Collections')).toBeInTheDocument()
+  })
+
+  it('renders root tags as rows', () => {
+    render(<TagDrillPage {...baseProps} />)
+    expect(screen.getByText('Mood')).toBeInTheDocument()
+    expect(screen.getByText('Genre')).toBeInTheDocument()
+    // Child tags not shown at root level
+    expect(screen.queryByText('Chill')).not.toBeInTheDocument()
+  })
+
+  it('shows all collections in grid at root', () => {
+    render(<TagDrillPage {...baseProps} />)
+    expect(screen.getByText('Road trip')).toBeInTheDocument()
+    expect(screen.getByText('Chill nights')).toBeInTheDocument()
+    expect(screen.getByText('Untagged')).toBeInTheDocument()
+  })
+
+  it('renders serving platter at root', () => {
+    render(<TagDrillPage {...baseProps} />)
+    expect(screen.getByTestId('serving-platter')).toBeInTheDocument()
+  })
+
+  it('tapping a root tag calls onSelectTag(tagId)', async () => {
+    const onSelectTag = vi.fn()
+    render(<TagDrillPage {...baseProps} onSelectTag={onSelectTag} />)
+    await userEvent.click(screen.getByText('Mood'))
+    expect(onSelectTag).toHaveBeenCalledWith('tag-mood')
+  })
+})
+
+describe('TagDrillPage — tag view', () => {
+  it('shows tag name and back button', () => {
+    render(<TagDrillPage {...baseProps} currentTagId="tag-mood" />)
+    expect(screen.getByText('Mood')).toBeInTheDocument()
+    expect(screen.getByLabelText(/back/i)).toBeInTheDocument()
+  })
+
+  it('shows child tags', () => {
+    render(<TagDrillPage {...baseProps} currentTagId="tag-mood" />)
+    expect(screen.getByText('Chill')).toBeInTheDocument()
+    expect(screen.getByText('Hype')).toBeInTheDocument()
+  })
+
+  it('shows collections under this tag including descendants', () => {
+    render(<TagDrillPage {...baseProps} currentTagId="tag-mood" />)
+    // col-2 has tag-chill (descendant of tag-mood)
+    expect(screen.getByText('Chill nights')).toBeInTheDocument()
+    // col-1 has tag-genre, NOT descendant of mood
+    expect(screen.queryByText('Road trip')).not.toBeInTheDocument()
+    // col-3 untagged
+    expect(screen.queryByText('Untagged')).not.toBeInTheDocument()
+  })
+
+  it('does NOT render serving platter when inside a tag', () => {
+    render(<TagDrillPage {...baseProps} currentTagId="tag-mood" />)
+    expect(screen.queryByTestId('serving-platter')).not.toBeInTheDocument()
+  })
+
+  it('back button at root tag (parent null) calls onSelectTag(null)', async () => {
+    const onSelectTag = vi.fn()
+    render(<TagDrillPage {...baseProps} currentTagId="tag-mood" onSelectTag={onSelectTag} />)
+    await userEvent.click(screen.getByLabelText(/back/i))
+    expect(onSelectTag).toHaveBeenCalledWith(null)
+  })
+
+  it('back button at child tag calls onSelectTag(parentId)', async () => {
+    const onSelectTag = vi.fn()
+    render(<TagDrillPage {...baseProps} currentTagId="tag-chill" onSelectTag={onSelectTag} />)
+    await userEvent.click(screen.getByLabelText(/back/i))
+    expect(onSelectTag).toHaveBeenCalledWith('tag-mood')
+  })
+
+  it('tapping a child tag drills deeper', async () => {
+    const onSelectTag = vi.fn()
+    render(<TagDrillPage {...baseProps} currentTagId="tag-mood" onSelectTag={onSelectTag} />)
+    await userEvent.click(screen.getByText('Chill'))
+    expect(onSelectTag).toHaveBeenCalledWith('tag-chill')
+  })
+
+  it('shows empty message when tag has no children and no collections', () => {
+    render(<TagDrillPage {...baseProps} currentTagId="tag-hype" />)
+    expect(screen.getByText(/no collections under this tag/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/TagManagerPage.jsx
+++ b/frontend/src/components/TagManagerPage.jsx
@@ -1,0 +1,372 @@
+import { useEffect, useMemo, useState } from 'react'
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  useSortable,
+  arrayMove,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { buildTagTree, findNode } from '@/lib/tagTree'
+
+function TagRow({
+  node,
+  depth,
+  renamingId,
+  renameValue,
+  setRenameValue,
+  startRename,
+  submitRename,
+  cancelRename,
+  confirmingId,
+  setConfirmingId,
+  onDeleteConfirm,
+  addingChildId,
+  addChildName,
+  setAddChildName,
+  startAddChild,
+  submitAddChild,
+  cancelAddChild,
+  dragHandleProps,
+  sortableRef,
+  sortableStyle,
+}) {
+  const isRenaming = renamingId === node.id
+  const isConfirming = confirmingId === node.id
+  const isAddingChild = addingChildId === node.id
+
+  return (
+    <div
+      ref={sortableRef}
+      style={sortableStyle}
+      data-testid={`tag-row-${node.id}`}
+      className="border-b border-border"
+    >
+      <div
+        className="flex items-center gap-2 px-2 py-1.5 hover:bg-bg-elevated group"
+        style={{ paddingLeft: `${depth * 16 + 8}px` }}
+      >
+        {dragHandleProps && (
+          <button
+            aria-label="Drag to reorder"
+            className="bg-transparent border-none text-text-dim cursor-grab p-0 text-base touch-none"
+            onClick={(e) => e.stopPropagation()}
+            {...dragHandleProps}
+          >
+            ⠿
+          </button>
+        )}
+        <div className="flex-1 min-w-0">
+          {isRenaming ? (
+            <input
+              className="text-sm text-text bg-transparent border-b border-accent outline-none w-full"
+              value={renameValue}
+              onChange={(e) => setRenameValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') submitRename(node)
+                if (e.key === 'Escape') cancelRename()
+              }}
+              onBlur={() => submitRename(node)}
+              autoFocus
+            />
+          ) : (
+            <span
+              className="text-sm text-text cursor-text"
+              onClick={() => startRename(node)}
+            >
+              {node.name}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-1 opacity-50 group-hover:opacity-100 transition-opacity">
+          <button
+            className="bg-transparent border border-border text-text-dim text-xs px-2 py-0.5 rounded cursor-pointer hover:bg-bg-elevated"
+            onClick={() => startAddChild(node)}
+            aria-label="Add child"
+          >
+            + Add child
+          </button>
+          {isConfirming ? (
+            <>
+              <button
+                className="bg-delete-red border-none text-white cursor-pointer text-xs font-semibold px-2 py-0.5 rounded"
+                aria-label="Confirm delete"
+                onClick={() => onDeleteConfirm(node.id)}
+              >
+                Delete
+              </button>
+              <button
+                className="bg-transparent border border-border text-text-dim cursor-pointer text-xs px-2 py-0.5 rounded"
+                aria-label="Cancel"
+                onClick={() => setConfirmingId(null)}
+              >
+                Cancel
+              </button>
+            </>
+          ) : (
+            <button
+              className="bg-transparent border border-border text-delete-red text-xs px-2 py-0.5 rounded cursor-pointer hover:bg-bg-elevated"
+              aria-label="Delete"
+              onClick={() => setConfirmingId(node.id)}
+            >
+              Delete
+            </button>
+          )}
+        </div>
+      </div>
+      {isAddingChild && (
+        <div
+          className="px-2 py-1.5 border-t border-border bg-bg-elevated"
+          style={{ paddingLeft: `${(depth + 1) * 16 + 8}px` }}
+        >
+          <input
+            className="text-sm text-text bg-transparent border-b border-accent outline-none w-full"
+            value={addChildName}
+            onChange={(e) => setAddChildName(e.target.value)}
+            placeholder="New child tag name"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') submitAddChild(node)
+              if (e.key === 'Escape') cancelAddChild()
+            }}
+            onBlur={cancelAddChild}
+            autoFocus
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function SortableTagRow(props) {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id: props.node.id })
+  const style = { transform: CSS.Transform.toString(transform), transition }
+  return (
+    <TagRow
+      {...props}
+      sortableRef={setNodeRef}
+      sortableStyle={style}
+      dragHandleProps={{ ...attributes, ...listeners }}
+    />
+  )
+}
+
+function TagBranch({
+  nodes,
+  depth,
+  parentId,
+  rowProps,
+  onReorderSiblings,
+}) {
+  const ids = useMemo(() => nodes.map((n) => n.id), [nodes])
+  const sensors = useSensors(useSensor(PointerSensor), useSensor(KeyboardSensor))
+
+  function handleDragEnd(event) {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIndex = ids.indexOf(active.id)
+    const newIndex = ids.indexOf(over.id)
+    if (oldIndex < 0 || newIndex < 0) return
+    const next = arrayMove(ids, oldIndex, newIndex)
+    onReorderSiblings(parentId, next)
+  }
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={ids} strategy={verticalListSortingStrategy}>
+        {nodes.map((node) => (
+          <div key={node.id}>
+            <SortableTagRow node={node} depth={depth} {...rowProps} />
+            {node.children.length > 0 && (
+              <TagBranch
+                nodes={node.children}
+                depth={depth + 1}
+                parentId={node.id}
+                rowProps={rowProps}
+                onReorderSiblings={onReorderSiblings}
+              />
+            )}
+          </div>
+        ))}
+      </SortableContext>
+    </DndContext>
+  )
+}
+
+export default function TagManagerPage({
+  tags,
+  onRename,
+  onDelete,
+  onCreate,
+  onMove,
+  onReorder,
+  onClose,
+}) {
+  const [renamingId, setRenamingId] = useState(null)
+  const [renameValue, setRenameValue] = useState('')
+  const [confirmingId, setConfirmingId] = useState(null)
+  const [addingChildId, setAddingChildId] = useState(null)
+  const [addChildName, setAddChildName] = useState('')
+  const [showRootCreate, setShowRootCreate] = useState(false)
+  const [rootCreateName, setRootCreateName] = useState('')
+
+  const tree = useMemo(() => buildTagTree(tags), [tags])
+
+  function startRename(node) {
+    setRenamingId(node.id)
+    setRenameValue(node.name)
+  }
+
+  function submitRename(node) {
+    const trimmed = renameValue.trim()
+    if (trimmed && trimmed !== node.name) {
+      onRename(node.id, trimmed)
+    }
+    setRenamingId(null)
+  }
+
+  function cancelRename() {
+    setRenamingId(null)
+  }
+
+  function handleDeleteConfirm(tagId) {
+    onDelete(tagId)
+    setConfirmingId(null)
+  }
+
+  function startAddChild(node) {
+    setAddingChildId(node.id)
+    setAddChildName('')
+  }
+
+  function submitAddChild(node) {
+    const trimmed = addChildName.trim()
+    if (trimmed) {
+      onCreate({ name: trimmed, parent_tag_id: node.id })
+    }
+    setAddingChildId(null)
+    setAddChildName('')
+  }
+
+  function cancelAddChild() {
+    setAddingChildId(null)
+    setAddChildName('')
+  }
+
+  function submitRootCreate() {
+    const trimmed = rootCreateName.trim()
+    if (trimmed) {
+      onCreate({ name: trimmed, parent_tag_id: null })
+    }
+    setShowRootCreate(false)
+    setRootCreateName('')
+  }
+
+  function handleReorder(parentId, tagIds) {
+    onReorder?.(parentId, tagIds)
+  }
+
+  function handleMove(tagId, payload) {
+    onMove?.(tagId, payload)
+  }
+
+  // Expose handlers for tests since simulating dnd-kit drag in jsdom is unreliable.
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.__tagManagerTestHandlers = { handleReorder, handleMove }
+      return () => {
+        if (window.__tagManagerTestHandlers) {
+          delete window.__tagManagerTestHandlers
+        }
+      }
+    }
+  })
+
+  const rowProps = {
+    renamingId,
+    renameValue,
+    setRenameValue,
+    startRename,
+    submitRename,
+    cancelRename,
+    confirmingId,
+    setConfirmingId,
+    onDeleteConfirm: handleDeleteConfirm,
+    addingChildId,
+    addChildName,
+    setAddChildName,
+    startAddChild,
+    submitAddChild,
+    cancelAddChild,
+  }
+
+  return (
+    <div className="w-full h-full flex flex-col bg-bg overflow-hidden">
+      <div className="flex items-center justify-between px-3 py-2 border-b border-border flex-shrink-0">
+        <div className="flex items-center gap-2">
+          <button
+            className="bg-transparent border border-border text-text-dim text-sm px-2 py-1 rounded cursor-pointer hover:bg-bg-elevated"
+            onClick={onClose}
+            aria-label="Back"
+          >
+            ← Back
+          </button>
+          <h1 className="text-base font-medium text-text">Tag Manager</h1>
+        </div>
+        <button
+          className="bg-transparent border border-border text-text text-sm px-2 py-1 rounded cursor-pointer hover:bg-bg-elevated"
+          onClick={() => {
+            setShowRootCreate(true)
+            setRootCreateName('')
+          }}
+        >
+          + New Tag
+        </button>
+      </div>
+      {showRootCreate && (
+        <div className="px-3 py-2 border-b border-border bg-bg-elevated flex-shrink-0">
+          <input
+            className="text-sm text-text bg-transparent border-b border-accent outline-none w-full"
+            value={rootCreateName}
+            onChange={(e) => setRootCreateName(e.target.value)}
+            placeholder="New tag name"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') submitRootCreate()
+              if (e.key === 'Escape') {
+                setShowRootCreate(false)
+                setRootCreateName('')
+              }
+            }}
+            onBlur={() => {
+              setShowRootCreate(false)
+              setRootCreateName('')
+            }}
+            autoFocus
+          />
+        </div>
+      )}
+      <div className="flex-1 overflow-y-auto">
+        {tags.length === 0 ? (
+          <p className="p-4 text-sm text-text-dim italic">
+            No tags yet — create one to organize collections.
+          </p>
+        ) : (
+          <TagBranch
+            nodes={tree}
+            depth={0}
+            parentId={null}
+            rowProps={rowProps}
+            onReorderSiblings={handleReorder}
+          />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/TagManagerPage.test.jsx
+++ b/frontend/src/components/TagManagerPage.test.jsx
@@ -1,0 +1,135 @@
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import TagManagerPage from './TagManagerPage'
+
+// Tags forming a small tree:
+// - Genre (root)
+//   - Rock (child)
+// - Mood (root)
+const TAGS = [
+  { id: 'genre', name: 'Genre', parent_tag_id: null, position: 0 },
+  { id: 'rock', name: 'Rock', parent_tag_id: 'genre', position: 0 },
+  { id: 'mood', name: 'Mood', parent_tag_id: null, position: 1 },
+]
+
+function renderManager(overrides = {}) {
+  const props = {
+    tags: TAGS,
+    onRename: vi.fn().mockResolvedValue(undefined),
+    onDelete: vi.fn().mockResolvedValue(undefined),
+    onCreate: vi.fn().mockResolvedValue({ id: 'new-tag' }),
+    onMove: vi.fn().mockResolvedValue(undefined),
+    onReorder: vi.fn().mockResolvedValue(undefined),
+    onClose: vi.fn(),
+    ...overrides,
+  }
+  const utils = render(<TagManagerPage {...props} />)
+  return { ...utils, props }
+}
+
+describe('TagManagerPage', () => {
+  it('renders nested tags as a tree', () => {
+    renderManager()
+    expect(screen.getByText('Genre')).toBeInTheDocument()
+    expect(screen.getByText('Rock')).toBeInTheDocument()
+    expect(screen.getByText('Mood')).toBeInTheDocument()
+  })
+
+  it('renders header with title, back button, and new tag button', () => {
+    const { props } = renderManager()
+    expect(screen.getByRole('heading', { name: /tag manager/i })).toBeInTheDocument()
+    const back = screen.getByRole('button', { name: /back/i })
+    expect(back).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /new tag/i })).toBeInTheDocument()
+  })
+
+  it('back button calls onClose', async () => {
+    const user = userEvent.setup()
+    const { props } = renderManager()
+    await user.click(screen.getByRole('button', { name: /back/i }))
+    expect(props.onClose).toHaveBeenCalled()
+  })
+
+  it('renders empty state when no tags', () => {
+    renderManager({ tags: [] })
+    expect(screen.getByText(/no tags yet/i)).toBeInTheDocument()
+  })
+
+  it('rename calls onRename(tagId, newName)', async () => {
+    const user = userEvent.setup()
+    const { props } = renderManager()
+
+    // Click the tag name to start renaming
+    await user.click(screen.getByText('Mood'))
+    const input = screen.getByDisplayValue('Mood')
+    await user.clear(input)
+    await user.type(input, 'Vibes')
+    await user.keyboard('{Enter}')
+
+    expect(props.onRename).toHaveBeenCalledWith('mood', 'Vibes')
+  })
+
+  it('delete shows confirmation, then calls onDelete on confirm', async () => {
+    const user = userEvent.setup()
+    const { props } = renderManager()
+
+    // Find delete buttons; pick the one for Mood
+    const moodRow = screen.getByTestId('tag-row-mood')
+    const deleteBtn = within(moodRow).getByRole('button', { name: /delete/i })
+    await user.click(deleteBtn)
+
+    // Confirmation appears
+    const confirmBtn = within(moodRow).getByRole('button', { name: /confirm delete/i })
+    await user.click(confirmBtn)
+
+    expect(props.onDelete).toHaveBeenCalledWith('mood')
+  })
+
+  it('add child calls onCreate with parent_tag_id', async () => {
+    const user = userEvent.setup()
+    const { props } = renderManager()
+
+    const genreRow = screen.getByTestId('tag-row-genre')
+    const addChildBtn = within(genreRow).getByRole('button', { name: /add child/i })
+    await user.click(addChildBtn)
+
+    const input = screen.getByPlaceholderText(/new child tag/i)
+    await user.type(input, 'Jazz')
+    await user.keyboard('{Enter}')
+
+    expect(props.onCreate).toHaveBeenCalledWith({ name: 'Jazz', parent_tag_id: 'genre' })
+  })
+
+  it('new tag button creates a root-level tag', async () => {
+    const user = userEvent.setup()
+    const { props } = renderManager()
+
+    await user.click(screen.getByRole('button', { name: /new tag/i }))
+    const input = screen.getByPlaceholderText(/new tag/i)
+    await user.type(input, 'Decade')
+    await user.keyboard('{Enter}')
+
+    expect(props.onCreate).toHaveBeenCalledWith({ name: 'Decade', parent_tag_id: null })
+  })
+
+  it('reorder under same parent calls onReorder(parentId, [...tagIds])', async () => {
+    const { props } = renderManager()
+    // Programmatically invoke the reorder handler exposed for tests via window.
+    // Since dnd-kit drag is hard to simulate in jsdom, we use the test-only hook
+    // exposed by the component.
+    const handler = window.__tagManagerTestHandlers
+    expect(handler).toBeDefined()
+
+    handler.handleReorder(null, ['mood', 'genre'])
+    expect(props.onReorder).toHaveBeenCalledWith(null, ['mood', 'genre'])
+  })
+
+  it('reparent calls onMove(tagId, { parent_tag_id, position })', async () => {
+    const { props } = renderManager()
+    const handler = window.__tagManagerTestHandlers
+    expect(handler).toBeDefined()
+
+    handler.handleMove('rock', { parent_tag_id: 'mood', position: 0 })
+    expect(props.onMove).toHaveBeenCalledWith('rock', { parent_tag_id: 'mood', position: 0 })
+  })
+})

--- a/frontend/src/components/TagPickerInput.jsx
+++ b/frontend/src/components/TagPickerInput.jsx
@@ -1,0 +1,147 @@
+import { useState } from 'react'
+import { X } from 'lucide-react'
+import { Badge } from './ui/badge'
+import {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from './ui/command'
+
+/**
+ * Inline tag chip editor.
+ *
+ * Props:
+ *   allTags          flat array of {id, name, parent_tag_id, position}
+ *   selectedTagIds   array of tag ids currently applied
+ *   onChange         (nextIds: string[]) => void
+ *   onCreate         async (name: string) => Promise<{ id: string }>
+ */
+function TagPickerInput({ allTags = [], selectedTagIds = [], onChange, onCreate }) {
+  const [query, setQuery] = useState('')
+
+  const tagsById = new Map(allTags.map((t) => [t.id, t]))
+  const selectedSet = new Set(selectedTagIds)
+  const selectedTags = selectedTagIds
+    .map((id) => tagsById.get(id))
+    .filter(Boolean)
+
+  const trimmed = query.trim()
+  const lowerQuery = trimmed.toLowerCase()
+
+  // Options: tags not already selected, filtered by query
+  const options = allTags.filter((tag) => {
+    if (selectedSet.has(tag.id)) return false
+    if (!trimmed) return true
+    return tag.name.toLowerCase().includes(lowerQuery)
+  })
+
+  const exactMatch = allTags.find(
+    (tag) => tag.name.toLowerCase() === lowerQuery,
+  )
+
+  function handleRemove(tagId) {
+    onChange?.(selectedTagIds.filter((id) => id !== tagId))
+  }
+
+  function handleSelect(tagId) {
+    if (selectedSet.has(tagId)) return
+    onChange?.([...selectedTagIds, tagId])
+    setQuery('')
+  }
+
+  async function handleCreate(name) {
+    if (!name) return
+    const created = await onCreate?.(name)
+    if (created?.id) {
+      onChange?.([...selectedTagIds, created.id])
+    }
+    setQuery('')
+  }
+
+  async function handleKeyDown(event) {
+    if (event.key !== 'Enter') return
+    if (!trimmed) return
+
+    // If there's an exact match (selected or not), prefer selecting it.
+    if (exactMatch) {
+      event.preventDefault()
+      if (!selectedSet.has(exactMatch.id)) {
+        handleSelect(exactMatch.id)
+      } else {
+        setQuery('')
+      }
+      return
+    }
+
+    // No exact match: only create if there are also no fuzzy options
+    // (so users can still arrow-select a partial match if they want).
+    if (options.length === 0) {
+      event.preventDefault()
+      await handleCreate(trimmed)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {selectedTags.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {selectedTags.map((tag) => (
+            <Badge
+              key={tag.id}
+              variant="secondary"
+              className="gap-1 bg-bg-elevated text-text border border-border"
+            >
+              <span>{tag.name}</span>
+              <button
+                type="button"
+                aria-label={`Remove ${tag.name}`}
+                onClick={() => handleRemove(tag.id)}
+                className="ml-1 inline-flex items-center justify-center rounded-sm text-text-dim hover:text-text"
+              >
+                <X className="size-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      <Command
+        shouldFilter={false}
+        className="border border-border bg-bg-elevated"
+        onKeyDown={handleKeyDown}
+      >
+        <CommandInput
+          role="combobox"
+          placeholder="Add a tag…"
+          value={query}
+          onValueChange={setQuery}
+        />
+        <CommandList>
+          {options.length === 0 && trimmed && !exactMatch && (
+            <CommandEmpty className="text-text-dim">
+              Press Enter to create &ldquo;{trimmed}&rdquo;
+            </CommandEmpty>
+          )}
+          {options.length > 0 && (
+            <CommandGroup>
+              {options.map((tag) => (
+                <CommandItem
+                  key={tag.id}
+                  value={tag.name}
+                  onSelect={() => handleSelect(tag.id)}
+                >
+                  {tag.name}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )}
+        </CommandList>
+      </Command>
+    </div>
+  )
+}
+
+export default TagPickerInput

--- a/frontend/src/components/TagPickerInput.test.jsx
+++ b/frontend/src/components/TagPickerInput.test.jsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import TagPickerInput from './TagPickerInput'
+
+const TAGS = [
+  { id: 'tag-1', name: 'rock', parent_tag_id: null, position: 0 },
+  { id: 'tag-2', name: 'jazz', parent_tag_id: null, position: 1 },
+  { id: 'tag-3', name: 'electronic', parent_tag_id: null, position: 2 },
+]
+
+function renderPicker(overrides = {}) {
+  const props = {
+    allTags: TAGS,
+    selectedTagIds: ['tag-1'],
+    onChange: vi.fn(),
+    onCreate: vi.fn(async (name) => ({ id: `new-${name}` })),
+    ...overrides,
+  }
+  return { ...render(<TagPickerInput {...props} />), props }
+}
+
+describe('TagPickerInput', () => {
+  it('renders selected tag chips', () => {
+    renderPicker({ selectedTagIds: ['tag-1', 'tag-2'] })
+    expect(screen.getByText('rock')).toBeInTheDocument()
+    expect(screen.getByText('jazz')).toBeInTheDocument()
+  })
+
+  it('removing a chip calls onChange without that tag id', async () => {
+    const { props } = renderPicker({ selectedTagIds: ['tag-1', 'tag-2'] })
+    const removeBtn = screen.getByRole('button', { name: /remove rock/i })
+    await userEvent.click(removeBtn)
+    expect(props.onChange).toHaveBeenCalledWith(['tag-2'])
+  })
+
+  it('typing filters dropdown to matching tags', async () => {
+    renderPicker({ selectedTagIds: [] })
+    const input = screen.getByRole('combobox')
+    await userEvent.type(input, 'jaz')
+    expect(screen.getByText('jazz')).toBeInTheDocument()
+    expect(screen.queryByText('rock')).not.toBeInTheDocument()
+    expect(screen.queryByText('electronic')).not.toBeInTheDocument()
+  })
+
+  it('selecting an option from the dropdown adds that tag id', async () => {
+    const { props } = renderPicker({ selectedTagIds: [] })
+    const input = screen.getByRole('combobox')
+    await userEvent.type(input, 'jazz')
+    await userEvent.click(screen.getByRole('option', { name: /jazz/i }))
+    expect(props.onChange).toHaveBeenCalledWith(['tag-2'])
+  })
+
+  it('does not show already-selected tags in the dropdown', async () => {
+    renderPicker({ selectedTagIds: ['tag-1'] })
+    const input = screen.getByRole('combobox')
+    await userEvent.type(input, 'rock')
+    // rock chip is rendered, but it should not be in the dropdown options
+    expect(screen.queryByRole('option', { name: /rock/i })).not.toBeInTheDocument()
+  })
+
+  it('pressing Enter on a novel name calls onCreate and adds the returned tag id', async () => {
+    const onCreate = vi.fn(async () => ({ id: 'new-id' }))
+    const { props } = renderPicker({ selectedTagIds: [], onCreate })
+    const input = screen.getByRole('combobox')
+    await userEvent.type(input, 'ambient')
+    await userEvent.keyboard('{Enter}')
+    expect(onCreate).toHaveBeenCalledWith('ambient')
+    // wait for promise to resolve and onChange to be called
+    await screen.findByRole('combobox')
+    expect(props.onChange).toHaveBeenCalledWith(['new-id'])
+  })
+
+  it('pressing Enter when query exactly matches an existing tag selects it instead of creating', async () => {
+    const onCreate = vi.fn()
+    const { props } = renderPicker({ selectedTagIds: [], onCreate })
+    const input = screen.getByRole('combobox')
+    await userEvent.type(input, 'jazz')
+    await userEvent.keyboard('{Enter}')
+    expect(onCreate).not.toHaveBeenCalled()
+    expect(props.onChange).toHaveBeenCalledWith(['tag-2'])
+  })
+
+  it('clears the query after a successful create', async () => {
+    renderPicker({ selectedTagIds: [] })
+    const input = screen.getByRole('combobox')
+    await userEvent.type(input, 'ambient')
+    await userEvent.keyboard('{Enter}')
+    // re-find input after re-render
+    const inputAfter = screen.getByRole('combobox')
+    expect(inputAfter).toHaveValue('')
+  })
+})

--- a/frontend/src/components/TagTreeSidebar.jsx
+++ b/frontend/src/components/TagTreeSidebar.jsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import { ChevronRight } from 'lucide-react';
+import { buildTagTree } from '../lib/tagTree';
+
+function TagNode({ node, selectedId, onSelect, depth = 0 }) {
+  const [open, setOpen] = useState(true);
+  const hasChildren = node.children.length > 0;
+  const isSelected = selectedId === node.id;
+
+  return (
+    <div>
+      <div
+        className={`flex items-center gap-1 px-2 py-1 rounded cursor-pointer hover:bg-bg-elevated ${
+          isSelected ? 'bg-bg-elevated text-text font-medium' : 'text-text-dim'
+        }`}
+        style={{ paddingLeft: `${depth * 12 + 8}px` }}
+        onClick={() => onSelect(node.id)}
+      >
+        {hasChildren ? (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              setOpen(!open);
+            }}
+            className="w-4 h-4 flex items-center justify-center"
+            aria-label={open ? 'Collapse' : 'Expand'}
+          >
+            <ChevronRight
+              className={`w-3 h-3 transition-transform ${open ? 'rotate-90' : ''}`}
+            />
+          </button>
+        ) : (
+          <span className="w-4" />
+        )}
+        <span className="text-sm truncate">{node.name}</span>
+      </div>
+      {hasChildren && open && (
+        <div>
+          {node.children.map((child) => (
+            <TagNode
+              key={child.id}
+              node={child}
+              selectedId={selectedId}
+              onSelect={onSelect}
+              depth={depth + 1}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function TagTreeSidebar({ tags, selectedTagId, onSelect, onOpenManager }) {
+  const tree = buildTagTree(tags);
+  return (
+    <aside className="w-56 border-r border-border h-full flex flex-col">
+      <div className="p-2 flex-1 overflow-y-auto">
+        <div
+          className={`px-2 py-1 rounded cursor-pointer hover:bg-bg-elevated text-sm ${
+            selectedTagId === null
+              ? 'bg-bg-elevated font-medium'
+              : 'text-text-dim'
+          }`}
+          onClick={() => onSelect(null)}
+        >
+          All
+        </div>
+        {tree.map((node) => (
+          <TagNode
+            key={node.id}
+            node={node}
+            selectedId={selectedTagId}
+            onSelect={onSelect}
+          />
+        ))}
+        {tags.length === 0 && (
+          <div className="px-2 py-4 text-xs text-text-dim">No tags yet</div>
+        )}
+      </div>
+      <button
+        onClick={onOpenManager}
+        className="border-t border-border px-3 py-2 text-xs text-text-dim hover:text-text text-left"
+      >
+        Manage tags
+      </button>
+    </aside>
+  );
+}

--- a/frontend/src/components/TagTreeSidebar.test.jsx
+++ b/frontend/src/components/TagTreeSidebar.test.jsx
@@ -1,0 +1,108 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { TagTreeSidebar } from './TagTreeSidebar'
+
+const TAGS = [
+  { id: 'a', name: 'Genre', parent_tag_id: null, position: 0 },
+  { id: 'b', name: 'Rock', parent_tag_id: 'a', position: 0 },
+  { id: 'c', name: 'Mood', parent_tag_id: null, position: 1 },
+]
+
+describe('TagTreeSidebar', () => {
+  it('renders the "All" root and each top-level tag', () => {
+    render(
+      <TagTreeSidebar
+        tags={TAGS}
+        selectedTagId={null}
+        onSelect={() => {}}
+        onOpenManager={() => {}}
+      />
+    )
+    expect(screen.getByText('All')).toBeInTheDocument()
+    expect(screen.getByText('Genre')).toBeInTheDocument()
+    expect(screen.getByText('Mood')).toBeInTheDocument()
+  })
+
+  it('shows children when parent is expanded (default open)', () => {
+    render(
+      <TagTreeSidebar
+        tags={TAGS}
+        selectedTagId={null}
+        onSelect={() => {}}
+        onOpenManager={() => {}}
+      />
+    )
+    expect(screen.getByText('Rock')).toBeInTheDocument()
+  })
+
+  it('hides children after collapsing the parent', () => {
+    render(
+      <TagTreeSidebar
+        tags={TAGS}
+        selectedTagId={null}
+        onSelect={() => {}}
+        onOpenManager={() => {}}
+      />
+    )
+    // The chevron toggle button is the only <button> sibling of Genre's label.
+    const buttons = screen.getAllByRole('button')
+    // First button is the chevron next to Genre (Mood is a leaf so has no chevron;
+    // last button is "Manage tags").
+    fireEvent.click(buttons[0])
+    expect(screen.queryByText('Rock')).not.toBeInTheDocument()
+  })
+
+  it('fires onSelect with tag id when a tag row is clicked', () => {
+    const onSelect = vi.fn()
+    render(
+      <TagTreeSidebar
+        tags={TAGS}
+        selectedTagId={null}
+        onSelect={onSelect}
+        onOpenManager={() => {}}
+      />
+    )
+    fireEvent.click(screen.getByText('Mood'))
+    expect(onSelect).toHaveBeenCalledWith('c')
+  })
+
+  it('fires onSelect(null) when the "All" row is clicked', () => {
+    const onSelect = vi.fn()
+    render(
+      <TagTreeSidebar
+        tags={TAGS}
+        selectedTagId={'a'}
+        onSelect={onSelect}
+        onOpenManager={() => {}}
+      />
+    )
+    fireEvent.click(screen.getByText('All'))
+    expect(onSelect).toHaveBeenCalledWith(null)
+  })
+
+  it('shows empty-state copy when there are no tags', () => {
+    render(
+      <TagTreeSidebar
+        tags={[]}
+        selectedTagId={null}
+        onSelect={() => {}}
+        onOpenManager={() => {}}
+      />
+    )
+    expect(screen.getByText('No tags yet')).toBeInTheDocument()
+  })
+
+  it('fires onOpenManager when "Manage tags" is clicked', () => {
+    const onOpenManager = vi.fn()
+    render(
+      <TagTreeSidebar
+        tags={TAGS}
+        selectedTagId={null}
+        onSelect={() => {}}
+        onOpenManager={onOpenManager}
+      />
+    )
+    fireEvent.click(screen.getByText('Manage tags'))
+    expect(onOpenManager).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/ViewToggle.jsx
+++ b/frontend/src/components/ViewToggle.jsx
@@ -1,0 +1,36 @@
+import { List, LayoutGrid } from 'lucide-react'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+
+/**
+ * Two-button toggle for collection view mode.
+ *
+ * Controlled component: parent owns the value. Persistence to localStorage
+ * is handled separately by `useCollectionsViewMode`.
+ *
+ * @param {{ value: 'list' | 'grid', onChange: (next: 'list' | 'grid') => void }} props
+ */
+export function ViewToggle({ value, onChange }) {
+  const handleValueChange = (groupValue) => {
+    // Base UI ToggleGroup (multiple=false) emits an array; with one item
+    // pressed, that array has one element. If the user clicks the active
+    // item it does not toggle off (single-select), so we ignore empty.
+    const next = groupValue?.[0]
+    if (!next || next === value) return
+    onChange(next)
+  }
+
+  return (
+    <ToggleGroup
+      value={[value]}
+      onValueChange={handleValueChange}
+      aria-label="Collections view mode"
+    >
+      <ToggleGroupItem value="list" aria-label="List view">
+        <List className="size-4" />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="grid" aria-label="Grid view">
+        <LayoutGrid className="size-4" />
+      </ToggleGroupItem>
+    </ToggleGroup>
+  )
+}

--- a/frontend/src/components/ViewToggle.test.jsx
+++ b/frontend/src/components/ViewToggle.test.jsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ViewToggle } from './ViewToggle'
+
+describe('ViewToggle', () => {
+  it('renders two buttons with list and grid aria labels', () => {
+    render(<ViewToggle value="list" onChange={() => {}} />)
+    expect(screen.getByRole('button', { name: /list view/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /grid view/i })).toBeInTheDocument()
+  })
+
+  it('marks the active button as pressed based on value', () => {
+    render(<ViewToggle value="list" onChange={() => {}} />)
+    expect(screen.getByRole('button', { name: /list view/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+    expect(screen.getByRole('button', { name: /grid view/i })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    )
+  })
+
+  it('reflects grid value as the pressed button', () => {
+    render(<ViewToggle value="grid" onChange={() => {}} />)
+    expect(screen.getByRole('button', { name: /grid view/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+  })
+
+  it('calls onChange with new value when inactive button is clicked', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<ViewToggle value="list" onChange={onChange} />)
+    await user.click(screen.getByRole('button', { name: /grid view/i }))
+    expect(onChange).toHaveBeenCalledWith('grid')
+  })
+
+  it('does not call onChange when the already-active button is clicked', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<ViewToggle value="list" onChange={onChange} />)
+    await user.click(screen.getByRole('button', { name: /list view/i }))
+    // Base UI ToggleGroup with multiple=false guarantees one item stays
+    // pressed; clicking the active button does not fire onValueChange with a
+    // different selection. Document this behavior here.
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/ui/badge.jsx
+++ b/frontend/src/components/ui/badge.jsx
@@ -1,0 +1,49 @@
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { cva } from "class-variance-authority";
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline:
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  render,
+  ...props
+}) {
+  return useRender({
+    defaultTagName: "span",
+    props: mergeProps({
+      className: cn(badgeVariants({ variant }), className),
+    }, props),
+    render,
+    state: {
+      slot: "badge",
+      variant,
+    },
+  });
+}
+
+export { Badge, badgeVariants }

--- a/frontend/src/components/ui/button.jsx
+++ b/frontend/src/components/ui/button.jsx
@@ -1,0 +1,57 @@
+import { Button as ButtonPrimitive } from "@base-ui/react/button"
+import { cva } from "class-variance-authority";
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        outline:
+          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+        ghost:
+          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+        destructive:
+          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default:
+          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        icon: "size-8",
+        "icon-xs":
+          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm":
+          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
+        "icon-lg": "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Button({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}) {
+  return (
+    <ButtonPrimitive
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props} />
+  );
+}
+
+export { Button, buttonVariants }

--- a/frontend/src/components/ui/card.jsx
+++ b/frontend/src/components/ui/card.jsx
@@ -1,0 +1,114 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({
+  className,
+  size = "default",
+  ...props
+}) {
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function CardHeader({
+  className,
+  ...props
+}) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function CardTitle({
+  className,
+  ...props
+}) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn(
+        "text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function CardDescription({
+  className,
+  ...props
+}) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props} />
+  );
+}
+
+function CardAction({
+  className,
+  ...props
+}) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function CardContent({
+  className,
+  ...props
+}) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-4 group-data-[size=sm]/card:px-3", className)}
+      {...props} />
+  );
+}
+
+function CardFooter({
+  className,
+  ...props
+}) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(
+        "flex items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3",
+        className
+      )}
+      {...props} />
+  );
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/frontend/src/components/ui/collapsible.jsx
+++ b/frontend/src/components/ui/collapsible.jsx
@@ -1,0 +1,21 @@
+import { Collapsible as CollapsiblePrimitive } from "@base-ui/react/collapsible"
+
+function Collapsible({
+  ...props
+}) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
+}
+
+function CollapsibleTrigger({
+  ...props
+}) {
+  return (<CollapsiblePrimitive.Trigger data-slot="collapsible-trigger" {...props} />);
+}
+
+function CollapsibleContent({
+  ...props
+}) {
+  return (<CollapsiblePrimitive.Panel data-slot="collapsible-content" {...props} />);
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/frontend/src/components/ui/command.jsx
+++ b/frontend/src/components/ui/command.jsx
@@ -1,0 +1,180 @@
+"use client"
+
+import * as React from "react"
+import { Command as CommandPrimitive } from "cmdk"
+
+import { cn } from "@/lib/utils"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  InputGroup,
+  InputGroupAddon,
+} from "@/components/ui/input-group"
+import { SearchIcon, CheckIcon } from "lucide-react"
+
+function Command({
+  className,
+  ...props
+}) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "flex size-full flex-col overflow-hidden rounded-xl! bg-popover p-1 text-popover-foreground",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function CommandDialog({
+  title = "Command Palette",
+  description = "Search for a command to run...",
+  children,
+  className,
+  showCloseButton = false,
+  ...props
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn("top-1/3 translate-y-0 overflow-hidden rounded-xl! p-0", className)}
+        showCloseButton={showCloseButton}>
+        {children}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CommandInput({
+  className,
+  ...props
+}) {
+  return (
+    <div data-slot="command-input-wrapper" className="p-1 pb-0">
+      <InputGroup
+        className="h-8! rounded-lg! border-input/30 bg-input/30 shadow-none! *:data-[slot=input-group-addon]:pl-2!">
+        <CommandPrimitive.Input
+          data-slot="command-input"
+          className={cn(
+            "w-full text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+            className
+          )}
+          {...props} />
+        <InputGroupAddon>
+          <SearchIcon className="size-4 shrink-0 opacity-50" />
+        </InputGroupAddon>
+      </InputGroup>
+    </div>
+  );
+}
+
+function CommandList({
+  className,
+  ...props
+}) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "no-scrollbar max-h-72 scroll-py-1 overflow-x-hidden overflow-y-auto outline-none",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function CommandEmpty({
+  className,
+  ...props
+}) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className={cn("py-6 text-center text-sm", className)}
+      {...props} />
+  );
+}
+
+function CommandGroup({
+  className,
+  ...props
+}) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "overflow-hidden p-1 text-foreground **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:py-1.5 **:[[cmdk-group-heading]]:text-xs **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:text-muted-foreground",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("-mx-1 h-px bg-border", className)}
+      {...props} />
+  );
+}
+
+function CommandItem({
+  className,
+  children,
+  ...props
+}) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "group/command-item relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none in-data-[slot=dialog-content]:rounded-lg! data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-selected:bg-muted data-selected:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-selected:*:[svg]:text-foreground",
+        className
+      )}
+      {...props}>
+      {children}
+      <CheckIcon
+        className="ml-auto opacity-0 group-has-data-[slot=command-shortcut]/command-item:hidden group-data-[checked=true]/command-item:opacity-100" />
+    </CommandPrimitive.Item>
+  );
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-data-selected/command-item:text-foreground",
+        className
+      )}
+      {...props} />
+  );
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+}

--- a/frontend/src/components/ui/dialog.jsx
+++ b/frontend/src/components/ui/dialog.jsx
@@ -1,0 +1,153 @@
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon } from "lucide-react"
+
+function Dialog({
+  ...props
+}) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({
+  ...props
+}) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({
+  ...props
+}) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({
+  ...props
+}) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}) {
+  return (
+    <DialogPrimitive.Backdrop
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Popup
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}>
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            render={
+              <Button variant="ghost" className="absolute top-2 right-2" size="icon-sm" />
+            }>
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Popup>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({
+  className,
+  ...props
+}) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2", className)}
+      {...props} />
+  );
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}>
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close render={<Button variant="outline" />}>
+          Close
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  );
+}
+
+function DialogTitle({
+  className,
+  ...props
+}) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-base leading-none font-medium", className)}
+      {...props} />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn(
+        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props} />
+  );
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/frontend/src/components/ui/input-group.jsx
+++ b/frontend/src/components/ui/input-group.jsx
@@ -1,0 +1,150 @@
+import * as React from "react"
+import { cva } from "class-variance-authority";
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+
+function InputGroup({
+  className,
+  ...props
+}) {
+  return (
+    <div
+      data-slot="input-group"
+      role="group"
+      className={cn(
+        "group/input-group relative flex h-8 w-full min-w-0 items-center rounded-lg border border-input transition-colors outline-none in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-disabled:bg-input/50 has-disabled:opacity-50 has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-3 has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-3 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>textarea]:h-auto dark:bg-input/30 dark:has-disabled:bg-input/80 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5",
+        className
+      )}
+      {...props} />
+  );
+}
+
+const inputGroupAddonVariants = cva(
+  "flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-sm font-medium text-muted-foreground select-none group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      align: {
+        "inline-start":
+          "order-first pl-2 has-[>button]:ml-[-0.3rem] has-[>kbd]:ml-[-0.15rem]",
+        "inline-end":
+          "order-last pr-2 has-[>button]:mr-[-0.3rem] has-[>kbd]:mr-[-0.15rem]",
+        "block-start":
+          "order-first w-full justify-start px-2.5 pt-2 group-has-[>input]/input-group:pt-2 [.border-b]:pb-2",
+        "block-end":
+          "order-last w-full justify-start px-2.5 pb-2 group-has-[>input]/input-group:pb-2 [.border-t]:pt-2",
+      },
+    },
+    defaultVariants: {
+      align: "inline-start",
+    },
+  }
+)
+
+function InputGroupAddon({
+  className,
+  align = "inline-start",
+  ...props
+}) {
+  return (
+    <div
+      role="group"
+      data-slot="input-group-addon"
+      data-align={align}
+      className={cn(inputGroupAddonVariants({ align }), className)}
+      onClick={(e) => {
+        if ((e.target).closest("button")) {
+          return
+        }
+        e.currentTarget.parentElement?.querySelector("input")?.focus()
+      }}
+      {...props} />
+  );
+}
+
+const inputGroupButtonVariants = cva("flex items-center gap-2 text-sm shadow-none", {
+  variants: {
+    size: {
+      xs: "h-6 gap-1 rounded-[calc(var(--radius)-3px)] px-1.5 [&>svg:not([class*='size-'])]:size-3.5",
+      sm: "",
+      "icon-xs":
+        "size-6 rounded-[calc(var(--radius)-3px)] p-0 has-[>svg]:p-0",
+      "icon-sm": "size-8 p-0 has-[>svg]:p-0",
+    },
+  },
+  defaultVariants: {
+    size: "xs",
+  },
+})
+
+function InputGroupButton({
+  className,
+  type = "button",
+  variant = "ghost",
+  size = "xs",
+  ...props
+}) {
+  return (
+    <Button
+      type={type}
+      data-size={size}
+      variant={variant}
+      className={cn(inputGroupButtonVariants({ size }), className)}
+      {...props} />
+  );
+}
+
+function InputGroupText({
+  className,
+  ...props
+}) {
+  return (
+    <span
+      className={cn(
+        "flex items-center gap-2 text-sm text-muted-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function InputGroupInput({
+  className,
+  ...props
+}) {
+  return (
+    <Input
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function InputGroupTextarea({
+  className,
+  ...props
+}) {
+  return (
+    <Textarea
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 resize-none rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent",
+        className
+      )}
+      {...props} />
+  );
+}
+
+export {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupText,
+  InputGroupInput,
+  InputGroupTextarea,
+}

--- a/frontend/src/components/ui/input.jsx
+++ b/frontend/src/components/ui/input.jsx
@@ -1,0 +1,23 @@
+import * as React from "react"
+import { Input as InputPrimitive } from "@base-ui/react/input"
+
+import { cn } from "@/lib/utils"
+
+function Input({
+  className,
+  type,
+  ...props
+}) {
+  return (
+    <InputPrimitive
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props} />
+  );
+}
+
+export { Input }

--- a/frontend/src/components/ui/textarea.jsx
+++ b/frontend/src/components/ui/textarea.jsx
@@ -1,0 +1,20 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({
+  className,
+  ...props
+}) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props} />
+  );
+}
+
+export { Textarea }

--- a/frontend/src/components/ui/toggle-group.jsx
+++ b/frontend/src/components/ui/toggle-group.jsx
@@ -1,0 +1,76 @@
+"use client";
+import * as React from "react"
+import { Toggle as TogglePrimitive } from "@base-ui/react/toggle"
+import { ToggleGroup as ToggleGroupPrimitive } from "@base-ui/react/toggle-group"
+
+import { cn } from "@/lib/utils"
+import { toggleVariants } from "@/components/ui/toggle"
+
+const ToggleGroupContext = React.createContext({
+  size: "default",
+  variant: "default",
+  spacing: 0,
+  orientation: "horizontal",
+})
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  spacing = 0,
+  orientation = "horizontal",
+  children,
+  ...props
+}) {
+  return (
+    <ToggleGroupPrimitive
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      data-spacing={spacing}
+      data-orientation={orientation}
+      style={{
+        "--gap": spacing
+      }}
+      className={cn(
+        "group/toggle-group flex w-fit flex-row items-center gap-[--spacing(var(--gap))] rounded-lg data-[size=sm]:rounded-[min(var(--radius-md),10px)] data-vertical:flex-col data-vertical:items-stretch",
+        className
+      )}
+      {...props}>
+      <ToggleGroupContext.Provider value={{ variant, size, spacing, orientation }}>
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive>
+  );
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant = "default",
+  size = "default",
+  ...props
+}) {
+  const context = React.useContext(ToggleGroupContext)
+
+  return (
+    <TogglePrimitive
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      data-spacing={context.spacing}
+      className={cn(
+        "shrink-0 group-data-[spacing=0]/toggle-group:rounded-none group-data-[spacing=0]/toggle-group:px-2 focus:z-10 focus-visible:z-10 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-end]:pr-1.5 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-start]:pl-1.5 group-data-horizontal/toggle-group:data-[spacing=0]:first:rounded-l-lg group-data-vertical/toggle-group:data-[spacing=0]:first:rounded-t-lg group-data-horizontal/toggle-group:data-[spacing=0]:last:rounded-r-lg group-data-vertical/toggle-group:data-[spacing=0]:last:rounded-b-lg group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:border-l-0 group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-l group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t",
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        className
+      )}
+      {...props}>
+      {children}
+    </TogglePrimitive>
+  );
+}
+
+export { ToggleGroup, ToggleGroupItem }

--- a/frontend/src/components/ui/toggle.jsx
+++ b/frontend/src/components/ui/toggle.jsx
@@ -1,0 +1,44 @@
+"use client"
+
+import { Toggle as TogglePrimitive } from "@base-ui/react/toggle"
+import { cva } from "class-variance-authority";
+
+import { cn } from "@/lib/utils"
+
+const toggleVariants = cva(
+  "group/toggle inline-flex items-center justify-center gap-1 rounded-lg text-sm font-medium whitespace-nowrap transition-all outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted data-[state=on]:bg-muted dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline: "border border-input bg-transparent hover:bg-muted",
+      },
+      size: {
+        default:
+          "h-8 min-w-8 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        sm: "h-7 min-w-7 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-9 min-w-9 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Toggle({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}) {
+  return (
+    <TogglePrimitive
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props} />
+  );
+}
+
+export { Toggle, toggleVariants }

--- a/frontend/src/hooks/useCollectionMembership.js
+++ b/frontend/src/hooks/useCollectionMembership.js
@@ -1,0 +1,66 @@
+import { useCallback, useState } from 'react'
+
+/**
+ * Centralized state + actions for the album -> collection-ids map.
+ *
+ * Shape: { [albumServiceId: string]: string[] /* collectionIds *\/ }
+ */
+export function useCollectionMembership(initial = {}) {
+  const [map, setMap] = useState(initial)
+
+  const addAlbumsToCollection = useCallback((collectionId, albumIds) => {
+    setMap(prev => {
+      const next = { ...prev }
+      for (const id of albumIds) {
+        const list = next[id] ?? []
+        if (!list.includes(collectionId)) next[id] = [...list, collectionId]
+      }
+      return next
+    })
+  }, [])
+
+  const removeAlbumFromCollection = useCallback((collectionId, albumId) => {
+    setMap(prev => {
+      const list = prev[albumId]
+      if (!list) return prev
+      const filtered = list.filter(id => id !== collectionId)
+      return { ...prev, [albumId]: filtered }
+    })
+  }, [])
+
+  const setCollectionMembership = useCallback((collectionId, albumIds) => {
+    setMap(prev => {
+      const next = {}
+      // Strip collectionId from all entries
+      for (const [aid, list] of Object.entries(prev)) {
+        const stripped = list.filter(id => id !== collectionId)
+        if (stripped.length) next[aid] = stripped
+      }
+      // Add collectionId to each new album
+      for (const aid of albumIds) {
+        next[aid] = [...(next[aid] ?? []), collectionId]
+      }
+      return next
+    })
+  }, [])
+
+  const deleteCollection = useCallback(collectionId => {
+    setMap(prev => {
+      const next = {}
+      for (const [aid, list] of Object.entries(prev)) {
+        const stripped = list.filter(id => id !== collectionId)
+        if (stripped.length) next[aid] = stripped
+      }
+      return next
+    })
+  }, [])
+
+  return {
+    albumCollectionMap: map,
+    setAlbumCollectionMap: setMap,
+    addAlbumsToCollection,
+    removeAlbumFromCollection,
+    setCollectionMembership,
+    deleteCollection,
+  }
+}

--- a/frontend/src/hooks/useCollectionMembership.test.js
+++ b/frontend/src/hooks/useCollectionMembership.test.js
@@ -1,0 +1,138 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { useCollectionMembership } from './useCollectionMembership'
+
+describe('useCollectionMembership', () => {
+  it('initializes with empty map by default', () => {
+    const { result } = renderHook(() => useCollectionMembership())
+    expect(result.current.albumCollectionMap).toEqual({})
+  })
+
+  it('initializes with the provided initial map', () => {
+    const initial = { a1: ['c1'] }
+    const { result } = renderHook(() => useCollectionMembership(initial))
+    expect(result.current.albumCollectionMap).toEqual({ a1: ['c1'] })
+  })
+
+  it('addAlbumsToCollection adds collectionId to each album', () => {
+    const { result } = renderHook(() => useCollectionMembership())
+    act(() => {
+      result.current.addAlbumsToCollection('c1', ['a1', 'a2'])
+    })
+    expect(result.current.albumCollectionMap).toEqual({
+      a1: ['c1'],
+      a2: ['c1'],
+    })
+  })
+
+  it('addAlbumsToCollection does not duplicate when already present', () => {
+    const { result } = renderHook(() => useCollectionMembership({ a1: ['c1'] }))
+    act(() => {
+      result.current.addAlbumsToCollection('c1', ['a1', 'a2'])
+    })
+    expect(result.current.albumCollectionMap).toEqual({
+      a1: ['c1'],
+      a2: ['c1'],
+    })
+  })
+
+  it('addAlbumsToCollection appends to existing collection list for an album', () => {
+    const { result } = renderHook(() => useCollectionMembership({ a1: ['c1'] }))
+    act(() => {
+      result.current.addAlbumsToCollection('c2', ['a1'])
+    })
+    expect(result.current.albumCollectionMap).toEqual({ a1: ['c1', 'c2'] })
+  })
+
+  it('removeAlbumFromCollection removes the collectionId from that album', () => {
+    const { result } = renderHook(() =>
+      useCollectionMembership({ a1: ['c1', 'c2'], a2: ['c1'] }),
+    )
+    act(() => {
+      result.current.removeAlbumFromCollection('c1', 'a1')
+    })
+    expect(result.current.albumCollectionMap).toEqual({
+      a1: ['c2'],
+      a2: ['c1'],
+    })
+  })
+
+  it('removeAlbumFromCollection is a no-op when album is not present', () => {
+    const initial = { a1: ['c1'] }
+    const { result } = renderHook(() => useCollectionMembership(initial))
+    act(() => {
+      result.current.removeAlbumFromCollection('c1', 'unknown')
+    })
+    expect(result.current.albumCollectionMap).toEqual({ a1: ['c1'] })
+  })
+
+  it('setCollectionMembership replaces the full set of albums for a collection', () => {
+    const { result } = renderHook(() =>
+      useCollectionMembership({
+        a1: ['c1', 'c2'],
+        a2: ['c1'],
+        a3: ['c2'],
+      }),
+    )
+    act(() => {
+      result.current.setCollectionMembership('c1', ['a3', 'a4'])
+    })
+    expect(result.current.albumCollectionMap).toEqual({
+      a1: ['c2'],
+      a3: ['c2', 'c1'],
+      a4: ['c1'],
+    })
+  })
+
+  it('setCollectionMembership with empty list removes collection from all albums', () => {
+    const { result } = renderHook(() =>
+      useCollectionMembership({ a1: ['c1'], a2: ['c1', 'c2'] }),
+    )
+    act(() => {
+      result.current.setCollectionMembership('c1', [])
+    })
+    expect(result.current.albumCollectionMap).toEqual({ a2: ['c2'] })
+  })
+
+  it('deleteCollection removes collectionId from every album list', () => {
+    const { result } = renderHook(() =>
+      useCollectionMembership({
+        a1: ['c1', 'c2'],
+        a2: ['c1'],
+        a3: ['c2'],
+      }),
+    )
+    act(() => {
+      result.current.deleteCollection('c1')
+    })
+    expect(result.current.albumCollectionMap).toEqual({
+      a1: ['c2'],
+      a3: ['c2'],
+    })
+  })
+
+  it('action functions are stable across renders', () => {
+    const { result, rerender } = renderHook(() => useCollectionMembership())
+    const first = {
+      addAlbumsToCollection: result.current.addAlbumsToCollection,
+      removeAlbumFromCollection: result.current.removeAlbumFromCollection,
+      setCollectionMembership: result.current.setCollectionMembership,
+      deleteCollection: result.current.deleteCollection,
+      setAlbumCollectionMap: result.current.setAlbumCollectionMap,
+    }
+    rerender()
+    expect(result.current.addAlbumsToCollection).toBe(first.addAlbumsToCollection)
+    expect(result.current.removeAlbumFromCollection).toBe(first.removeAlbumFromCollection)
+    expect(result.current.setCollectionMembership).toBe(first.setCollectionMembership)
+    expect(result.current.deleteCollection).toBe(first.deleteCollection)
+    expect(result.current.setAlbumCollectionMap).toBe(first.setAlbumCollectionMap)
+  })
+
+  it('exposes setAlbumCollectionMap escape hatch for direct overrides', () => {
+    const { result } = renderHook(() => useCollectionMembership())
+    act(() => {
+      result.current.setAlbumCollectionMap({ a1: ['c1'] })
+    })
+    expect(result.current.albumCollectionMap).toEqual({ a1: ['c1'] })
+  })
+})

--- a/frontend/src/hooks/useCollectionsViewMode.js
+++ b/frontend/src/hooks/useCollectionsViewMode.js
@@ -1,0 +1,31 @@
+import { useState, useCallback } from 'react'
+
+const STORAGE_KEY = 'bummer.collectionsView'
+const DEFAULT_VALUE = 'list'
+const VALID_VALUES = ['list', 'grid']
+
+function readInitial() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored && VALID_VALUES.includes(stored)) return stored
+  } catch {
+    // ignore
+  }
+  return DEFAULT_VALUE
+}
+
+export function useCollectionsViewMode() {
+  const [value, setValueState] = useState(readInitial)
+
+  const setValue = useCallback((next) => {
+    if (!VALID_VALUES.includes(next)) return
+    setValueState(next)
+    try {
+      localStorage.setItem(STORAGE_KEY, next)
+    } catch {
+      // ignore
+    }
+  }, [])
+
+  return [value, setValue]
+}

--- a/frontend/src/hooks/useCollectionsViewMode.test.js
+++ b/frontend/src/hooks/useCollectionsViewMode.test.js
@@ -1,0 +1,34 @@
+import { renderHook, act } from '@testing-library/react'
+import { useCollectionsViewMode } from './useCollectionsViewMode'
+
+const STORAGE_KEY = 'bummer.collectionsView'
+
+describe('useCollectionsViewMode', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it("returns default 'list' when localStorage is empty", () => {
+    const { result } = renderHook(() => useCollectionsViewMode())
+    expect(result.current[0]).toBe('list')
+  })
+
+  it('returns persisted value when localStorage has a valid value', () => {
+    localStorage.setItem(STORAGE_KEY, 'grid')
+    const { result } = renderHook(() => useCollectionsViewMode())
+    expect(result.current[0]).toBe('grid')
+  })
+
+  it('setter updates state and writes to localStorage', () => {
+    const { result } = renderHook(() => useCollectionsViewMode())
+    act(() => result.current[1]('grid'))
+    expect(result.current[0]).toBe('grid')
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('grid')
+  })
+
+  it("falls back to default when persisted value is invalid", () => {
+    localStorage.setItem(STORAGE_KEY, 'something-bogus')
+    const { result } = renderHook(() => useCollectionsViewMode())
+    expect(result.current[0]).toBe('list')
+  })
+})

--- a/frontend/src/lib/tagTree.js
+++ b/frontend/src/lib/tagTree.js
@@ -1,0 +1,39 @@
+export function buildTagTree(flatTags) {
+  const byId = new Map();
+  for (const t of flatTags) byId.set(t.id, { ...t, children: [] });
+  const roots = [];
+  for (const node of byId.values()) {
+    if (node.parent_tag_id && byId.has(node.parent_tag_id)) {
+      byId.get(node.parent_tag_id).children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+  const sortRec = (nodes) => {
+    nodes.sort((a, b) => a.position - b.position);
+    nodes.forEach((n) => sortRec(n.children));
+  };
+  sortRec(roots);
+  return roots;
+}
+
+export function findNode(tree, tagId) {
+  for (const node of tree) {
+    if (node.id === tagId) return node;
+    const sub = findNode(node.children, tagId);
+    if (sub) return sub;
+  }
+  return null;
+}
+
+export function getDescendantIds(tree, tagId) {
+  const result = new Set();
+  const node = findNode(tree, tagId);
+  if (!node) return result;
+  const walk = (n) => {
+    result.add(n.id);
+    n.children.forEach(walk);
+  };
+  walk(node);
+  return result;
+}

--- a/frontend/src/lib/tagTree.test.js
+++ b/frontend/src/lib/tagTree.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { buildTagTree, getDescendantIds, findNode } from './tagTree'
+
+const FLAT = [
+  { id: 'a', name: 'Genre', parent_tag_id: null, position: 0 },
+  { id: 'b', name: 'Rock', parent_tag_id: 'a', position: 1 },
+  { id: 'c', name: 'Jazz', parent_tag_id: 'a', position: 0 },
+  { id: 'd', name: 'Mood', parent_tag_id: null, position: 1 },
+  { id: 'e', name: 'Bebop', parent_tag_id: 'c', position: 0 },
+]
+
+describe('buildTagTree', () => {
+  it('returns empty array for empty input', () => {
+    expect(buildTagTree([])).toEqual([])
+  })
+
+  it('nests children under parents', () => {
+    const tree = buildTagTree(FLAT)
+    expect(tree).toHaveLength(2)
+    const genre = tree.find((n) => n.id === 'a')
+    expect(genre.children.map((n) => n.id)).toEqual(['c', 'b'])
+  })
+
+  it('sorts siblings by position recursively', () => {
+    const tree = buildTagTree(FLAT)
+    expect(tree.map((n) => n.id)).toEqual(['a', 'd'])
+    const jazz = tree[0].children.find((n) => n.id === 'c')
+    expect(jazz.children.map((n) => n.id)).toEqual(['e'])
+  })
+
+  it('treats orphans (missing parent) as roots', () => {
+    const orphans = [{ id: 'x', name: 'X', parent_tag_id: 'missing', position: 0 }]
+    const tree = buildTagTree(orphans)
+    expect(tree).toHaveLength(1)
+    expect(tree[0].id).toBe('x')
+  })
+})
+
+describe('findNode', () => {
+  it('finds a root node', () => {
+    const tree = buildTagTree(FLAT)
+    expect(findNode(tree, 'a').name).toBe('Genre')
+  })
+
+  it('finds a deeply nested node', () => {
+    const tree = buildTagTree(FLAT)
+    expect(findNode(tree, 'e').name).toBe('Bebop')
+  })
+
+  it('returns null for missing id', () => {
+    expect(findNode(buildTagTree(FLAT), 'zzz')).toBeNull()
+  })
+})
+
+describe('getDescendantIds', () => {
+  it('returns set with the node and all descendants', () => {
+    const tree = buildTagTree(FLAT)
+    const ids = getDescendantIds(tree, 'a')
+    expect(ids).toEqual(new Set(['a', 'b', 'c', 'e']))
+  })
+
+  it('returns just the node id when leaf', () => {
+    const tree = buildTagTree(FLAT)
+    expect(getDescendantIds(tree, 'e')).toEqual(new Set(['e']))
+  })
+
+  it('returns empty set for missing id', () => {
+    const tree = buildTagTree(FLAT)
+    expect(getDescendantIds(tree, 'zzz')).toEqual(new Set())
+  })
+})

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -1,0 +1,6 @@
+import { clsx } from "clsx";
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs) {
+  return twMerge(clsx(inputs));
+}

--- a/frontend/src/tailwind.css
+++ b/frontend/src/tailwind.css
@@ -1,4 +1,7 @@
 @import "tailwindcss";
+@import "tw-animate-css";
+
+@custom-variant dark (&:is(.dark *));
 
 /* Hide all scrollbars app-wide */
 * {
@@ -179,4 +182,118 @@
     width: 100%;
     left: 0;
   }
+}
+
+/* === shadcn/ui theme tokens ===
+   Added by `npx shadcn init`. Maps shadcn's named tokens (background, foreground,
+   card, primary, etc.) onto CSS variables defined in :root / .dark below.
+   Note: --color-border was already defined above (#2e2e2e) for the app's existing
+   border-border usage. The shadcn :root block sets --border to a matching value so
+   border-border keeps its current visual weight. */
+@theme inline {
+  --color-sidebar-ring: var(--sidebar-ring);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar: var(--sidebar);
+  --color-chart-5: var(--chart-5);
+  --color-chart-4: var(--chart-4);
+  --color-chart-3: var(--chart-3);
+  --color-chart-2: var(--chart-2);
+  --color-chart-1: var(--chart-1);
+  --color-ring: var(--ring);
+  --color-input: var(--input);
+  --color-destructive: var(--destructive);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-muted: var(--muted);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-secondary: var(--secondary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-primary: var(--primary);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-popover: var(--popover);
+  --color-card-foreground: var(--card-foreground);
+  --color-card: var(--card);
+  --color-foreground: var(--foreground);
+  --color-background: var(--background);
+  --radius-sm: calc(var(--radius) * 0.6);
+  --radius-md: calc(var(--radius) * 0.8);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) * 1.4);
+  --radius-2xl: calc(var(--radius) * 1.8);
+  --radius-3xl: calc(var(--radius) * 2.2);
+  --radius-4xl: calc(var(--radius) * 2.6);
+}
+
+:root {
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --chart-1: oklch(0.87 0 0);
+  --chart-2: oklch(0.556 0 0);
+  --chart-3: oklch(0.439 0 0);
+  --chart-4: oklch(0.371 0 0);
+  --chart-5: oklch(0.269 0 0);
+  --radius: 0.625rem;
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.922 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --chart-1: oklch(0.87 0 0);
+  --chart-2: oklch(0.556 0 0);
+  --chart-3: oklch(0.439 0 0);
+  --chart-4: oklch(0.371 0 0);
+  --chart-5: oklch(0.269 0 0);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.556 0 0);
 }

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -14,6 +14,12 @@ globalThis.IntersectionObserver = class IntersectionObserver {
   disconnect() {}
 }
 
+// jsdom does not implement Element.prototype.scrollIntoView — stub it.
+// cmdk (used by shadcn Command) calls this on highlighted items.
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = function scrollIntoView() {}
+}
+
 // jsdom does not implement matchMedia — stub it so useIsMobile doesn't crash.
 // Returns matches: false (desktop) by default; individual tests can override.
 Object.defineProperty(window, 'matchMedia', {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -20,6 +20,11 @@ function rewriteRootToApp() {
 
 export default defineConfig({
   plugins: [react(), tailwindcss(), rewriteRootToApp()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
   define: {
     __APP_VERSION__: JSON.stringify(
       process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) ?? 'dev'

--- a/supabase/migrations/20260505053608_create_tags.sql
+++ b/supabase/migrations/20260505053608_create_tags.sql
@@ -1,0 +1,47 @@
+CREATE TABLE public.tags (
+    id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+    user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    name text NOT NULL,
+    parent_tag_id uuid REFERENCES public.tags(id) ON DELETE CASCADE,
+    position integer NOT NULL DEFAULT 0,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE NULLS NOT DISTINCT (user_id, parent_tag_id, name)
+);
+
+CREATE INDEX idx_tags_user_parent ON public.tags(user_id, parent_tag_id, position);
+
+ALTER TABLE public.tags ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users read own tags" ON public.tags
+    FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "Users insert own tags" ON public.tags
+    FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users update own tags" ON public.tags
+    FOR UPDATE USING (auth.uid() = user_id);
+CREATE POLICY "Users delete own tags" ON public.tags
+    FOR DELETE USING (auth.uid() = user_id);
+
+CREATE TABLE public.collection_tags (
+    collection_id uuid NOT NULL REFERENCES public.collections(id) ON DELETE CASCADE,
+    tag_id uuid NOT NULL REFERENCES public.tags(id) ON DELETE CASCADE,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (collection_id, tag_id)
+);
+
+CREATE INDEX idx_collection_tags_tag ON public.collection_tags(tag_id);
+
+ALTER TABLE public.collection_tags ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users read own collection_tags" ON public.collection_tags
+    FOR SELECT USING (
+        EXISTS (SELECT 1 FROM public.collections c WHERE c.id = collection_id AND c.user_id = auth.uid())
+    );
+CREATE POLICY "Users insert own collection_tags" ON public.collection_tags
+    FOR INSERT WITH CHECK (
+        EXISTS (SELECT 1 FROM public.collections c WHERE c.id = collection_id AND c.user_id = auth.uid())
+        AND EXISTS (SELECT 1 FROM public.tags t WHERE t.id = tag_id AND t.user_id = auth.uid())
+    );
+CREATE POLICY "Users delete own collection_tags" ON public.collection_tags
+    FOR DELETE USING (
+        EXISTS (SELECT 1 FROM public.collections c WHERE c.id = collection_id AND c.user_id = auth.uid())
+    );

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,50 @@
+// Repo-root Vitest config so `vitest --run` works regardless of cwd.
+//
+// Background: `npx --prefix frontend vitest --run` only changes where npx
+// resolves the binary; it does NOT change cwd. With cwd at the repo root,
+// Vitest cannot find `frontend/vite.config.js`, so `@vitejs/plugin-react`
+// never loads and every test file fails with "ReferenceError: React is not
+// defined". The standard invocation `npm --prefix frontend test -- --run`
+// works because npm changes cwd to the package dir before running scripts.
+//
+// We chdir into `frontend/` so transitive `vite/internal` imports inside the
+// React plugin resolve against `frontend/node_modules/`, then load the React
+// plugin and define the test environment inline. We don't reuse
+// `frontend/vite.config.js` directly because it relies on esbuild-injected
+// `__dirname`, which isn't available when the file is loaded via dynamic
+// import in the parent ESM scope.
+import { fileURLToPath } from 'node:url'
+import { chdir } from 'node:process'
+import { resolve } from 'node:path'
+
+const frontendDir = fileURLToPath(new URL('./frontend/', import.meta.url))
+chdir(frontendDir)
+
+export default async () => {
+  const { default: react } = await import(
+    new URL('./frontend/node_modules/@vitejs/plugin-react/dist/index.js', import.meta.url).href
+  )
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: {
+        '@': resolve(frontendDir, 'src'),
+      },
+    },
+    define: {
+      __APP_VERSION__: JSON.stringify(
+        process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) ?? 'dev'
+      ),
+    },
+    root: frontendDir,
+    test: {
+      environment: 'jsdom',
+      environmentOptions: {
+        jsdom: { url: 'http://localhost' },
+      },
+      setupFiles: [resolve(frontendDir, 'src/test/setup.js')],
+      globals: true,
+      exclude: ['**/node_modules/**', '**/e2e/**'],
+    },
+  }
+}


### PR DESCRIPTION
Closes #125

## Summary
- Hierarchical tags as data model, folder-style browsing in UX
- Sidebar tag tree (desktop) + drill-down navigation (mobile)
- List and grid view modes with persisted toggle
- Mosaic collection cards (or pinned cover when set)
- shadcn/ui adopted for tree, toggle, card, command, badge primitives
- `useCollectionMembership` hook centralizes scattered map mutations
- Tag manager page for create/rename/delete/reparent
- Inline tag picker on collection detail
- Serving platter (Recently Added/Played + AlbumPromptBar) preserved on root view

## Spec & Plan
- Spec: `docs/specs/2026-05-04-collections-overhaul-design.md`
- Plan: `docs/plans/2026-05-04-collections-overhaul.md`

## Database
- New tables: `tags` (forest, per user), `collection_tags` (many-to-many)
- Migration: `20260505053608_create_tags.sql` (already applied to prod)
- RLS scoped per user via `auth.uid()` and existing `collections.user_id`

## Tests
- 643 frontend tests pass (45 files)
- Backend tag endpoints tested in `test_tags.py` and `test_metadata.py` (need local pytest run to confirm execution)

## Known gaps (follow-ups)
- TagManagerPage cross-branch reparent drag UI not wired (same-branch reorder works; handler surface exists)
- `collection_tags` map fetched client-side via supabase (RLS-scoped) instead of through a backend endpoint — documented inline shortcut

## Test plan
- [ ] Desktop: sidebar shows tag tree, click tag filters collections, grid/list toggle persists
- [ ] Desktop: open collection → tag chips render, add/remove tags via picker
- [ ] Desktop: click "Manage tags" → tag manager page, create/rename/delete/reorder tags
- [ ] Mobile: drill-down into tags works, back button returns, "+ New Collection" button creates at root
- [ ] Bulk add from library still works
- [ ] Recently Added / Played serving platter still works at root

🤖 Generated with [Claude Code](https://claude.com/claude-code)