### PR TITLE
Release branches: workflows + docs [140]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, rc, production]
 
 jobs:
   lint:

--- a/.github/workflows/prod-smoke-test.yml
+++ b/.github/workflows/prod-smoke-test.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Hit /health with retries
         env:
           PROD_URL: ${{ vars.PROD_URL }}
+          EXPECTED_SHA: ${{ github.sha }}
         run: |
           if [ -z "$PROD_URL" ]; then
             echo "PROD_URL repository variable is not set" >&2
@@ -22,7 +23,7 @@ jobs:
           fi
 
           attempts=0
-          max_attempts=5
+          max_attempts=10
           delay=20
 
           while [ $attempts -lt $max_attempts ]; do
@@ -31,13 +32,15 @@ jobs:
 
             http_code=$(curl -s -o /tmp/health.json -w "%{http_code}" --max-time 15 "$PROD_URL/health" || echo "000")
             body=$(cat /tmp/health.json 2>/dev/null || echo "")
+            status=$(jq -r '.status // empty' /tmp/health.json 2>/dev/null || true)
+            deployed_sha=$(jq -r '.sha // empty' /tmp/health.json 2>/dev/null || true)
 
-            if [ "$http_code" = "200" ] && echo "$body" | grep -q '"status":"ok"'; then
-              echo "Smoke test passed: $body"
+            if [ "$http_code" = "200" ] && [ "$status" = "ok" ] && [ "$deployed_sha" = "$EXPECTED_SHA" ]; then
+              echo "Smoke test passed: status=$status sha=$deployed_sha"
               exit 0
             fi
 
-            echo "Attempt $attempts failed (status=$http_code, body=$body). Retrying in ${delay}s..."
+            echo "Attempt $attempts failed (status_code=$http_code, status=$status, deployed_sha=$deployed_sha, expected_sha=$EXPECTED_SHA, body=$body). Retrying in ${delay}s..."
             sleep $delay
           done
 

--- a/.github/workflows/prod-smoke-test.yml
+++ b/.github/workflows/prod-smoke-test.yml
@@ -1,0 +1,45 @@
+name: Production Smoke Test
+
+on:
+  push:
+    branches: [production]
+
+jobs:
+  smoke-test:
+    name: Smoke test /health on production
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for Vercel deploy to propagate
+        run: sleep 90
+
+      - name: Hit /health with retries
+        env:
+          PROD_URL: ${{ vars.PROD_URL }}
+        run: |
+          if [ -z "$PROD_URL" ]; then
+            echo "PROD_URL repository variable is not set" >&2
+            exit 1
+          fi
+
+          attempts=0
+          max_attempts=5
+          delay=20
+
+          while [ $attempts -lt $max_attempts ]; do
+            attempts=$((attempts + 1))
+            echo "Attempt $attempts: GET $PROD_URL/health"
+
+            http_code=$(curl -s -o /tmp/health.json -w "%{http_code}" --max-time 15 "$PROD_URL/health" || echo "000")
+            body=$(cat /tmp/health.json 2>/dev/null || echo "")
+
+            if [ "$http_code" = "200" ] && echo "$body" | grep -q '"status":"ok"'; then
+              echo "Smoke test passed: $body"
+              exit 0
+            fi
+
+            echo "Attempt $attempts failed (status=$http_code, body=$body). Retrying in ${delay}s..."
+            sleep $delay
+          done
+
+          echo "Smoke test failed after $max_attempts attempts" >&2
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ Avoid patterns that trigger sandbox approval prompts:
 - **`main` is production** — merging to main triggers a Vercel production deploy to live users. Treat every merge as a production release. Never push, force-push, or merge to main without passing CI and user approval.
 - **Issue-first**: every code change starts from a GitHub issue
 - **Branch from issue**: branch name is `<issue-number>-<short-title>`, e.g. `18-library-sync-wipes-cache`. No `feat/` prefix.
+- **Session bootstrap**: at the start of every session, check your branch and see if it's got an associated GitHub issue for context.
 - **Draft PR immediately**: push branch and open a draft PR linking the issue before writing code. This gives visibility and a place for discussion.
 - **Auto-commit** when all tests pass — no need to ask permission
 - **One commit per agent task** — each background agent should commit its own work when done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ Avoid patterns that trigger sandbox approval prompts:
 - **`main` is production** — merging to main triggers a Vercel production deploy to live users. Treat every merge as a production release. Never push, force-push, or merge to main without passing CI and user approval.
 - **Issue-first**: every code change starts from a GitHub issue
 - **Branch from issue**: branch name is `<issue-number>-<short-title>`, e.g. `18-library-sync-wipes-cache`. No `feat/` prefix.
+- **Session bootstrap**: at the start of any session, check `git branch --show-current`. If the branch name starts with `<digits>-` (e.g. `152-collection-open-crash`), that prefix is the GitHub issue number for the work in this worktree. Fetch the issue body via `gh issue view <num> --repo toofanian/bummer` before doing anything else, and treat it as the source of truth for what to build/fix. This applies even if the user's first message is terse or seems unrelated — confirm scope against the issue first.
 - **Draft PR immediately**: push branch and open a draft PR linking the issue before writing code. This gives visibility and a place for discussion.
 - **Auto-commit** when all tests pass — no need to ask permission
 - **One commit per agent task** — each background agent should commit its own work when done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ bummer/
 - `IS_PREVIEW` (computed from `VITE_VERCEL_ENV`) is used only in `useSpotifyAuth.js` to route Spotify OAuth through the proxy; it does not bypass authentication
 - Preview users' data lives in the prod DB alongside real users, isolated by `user_id`
 - Prod (`VERCEL_ENV=production`) is unaffected: Vercel injects `VERCEL_ENV=production` for prod deploys, which cannot be overridden from the Vercel env-var UI in the Production scope
+- The `rc` branch deploys to `staging.bummer.app` (via Vercel branch deploy + custom domain). Unlike preview deploys, `rc` uses **direct Spotify OAuth** (its callback URI is registered in the Spotify Dashboard) — not the callback proxy. RC shares the prod Supabase DB, same as preview deploys.
 
 ## Conventions
 
@@ -78,7 +79,7 @@ Avoid patterns that trigger sandbox approval prompts:
 
 ## Git workflow
 
-- **`main` is production** — merging to main triggers a Vercel production deploy to live users. Treat every merge as a production release. Never push, force-push, or merge to main without passing CI and user approval.
+- **`production` is production** — merging to `production` triggers a Vercel production deploy to live users. Treat every merge to `production` as a release. Never push, force-push, or merge to `production` without passing CI and user approval. `main` is the integration branch and gets preview deploys per PR; merges to `main` do NOT deploy to prod.
 - **Issue-first**: every code change starts from a GitHub issue
 - **Branch from issue**: branch name is `<issue-number>-<short-title>`, e.g. `18-library-sync-wipes-cache`. No `feat/` prefix.
 - **Session bootstrap**: at the start of every session, check your branch and see if it's got an associated GitHub issue for context.
@@ -87,6 +88,23 @@ Avoid patterns that trigger sandbox approval prompts:
 - **One commit per agent task** — each background agent should commit its own work when done
 - **Never commit directly to `main`** — `main` is branch-protected. All changes go through a PR, no matter how small.
 - Commit message format: concise imperative summary + bullet points for details + `Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>`
+
+### Release flow (rc + production)
+
+Three long-lived branches: `main` (integration), `rc` (release candidate, deploys to `staging.bummer.app`), `production` (live).
+
+1. Feature work merges to `main` via PR (current behavior).
+2. When a batch is ready to ship, fast-forward `rc` to current `main` HEAD: `git push origin main:rc`. This is the code freeze.
+3. Soak the staging URL (`staging.bummer.app`) on phone + Mac with real Spotify auth.
+4. Bug found during soak → fix on `rc` directly (PR `fix/x` → `rc`), then backport to `main` (PR or cherry-pick). Soak continues — no reset. **Every rc-only fix MUST land on `main` before the next `rc` snapshot, or it gets clobbered.**
+5. Stable → open PR `rc` → `production`. CI runs (lint + tests). Merge with a merge commit (no squash, no rebase — the merge commit is the ship event and the revert target).
+6. Tag the release: `git tag vX.Y.Z && git push --tags` (manual semver bump).
+7. Vercel auto-deploys `production`. The `Production Smoke Test` workflow hits `/health` and fails loudly if broken.
+
+**Rollback:**
+- Fast: Vercel UI → Instant Rollback to prior production deployment.
+- Durable: `git revert -m 1 <merge-sha>` on `production` and push.
+
 - **Local preview before PR**: after tests pass, run `make dev-bg` (pass `MAIN_REPO=<path-to-main-repo>` if in a worktree) to start dev servers in the background, then tell the user to open `http://localhost:5173` and review. Do not push or open a PR until the user confirms the local preview looks good. Run `make stop` to clean up after. If ports 5173/8000 are already in use (another agent's preview is running), do NOT kill them — just tell the user another preview is active and wait for them to finish that review first.
 
 ## Local dev setup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ Avoid patterns that trigger sandbox approval prompts:
 Three long-lived branches: `main` (integration), `rc` (release candidate, deploys to `staging.bummer.app`), `production` (live).
 
 1. Feature work merges to `main` via PR (current behavior).
-2. When a batch is ready to ship, fast-forward `rc` to current `main` HEAD: `git push origin main:rc`. This is the code freeze.
+2. When a batch is ready to ship, snapshot `rc` from current `main` HEAD: `git push origin main:rc`. This is the code freeze. If `rc` has diverged from `main` (because an rc-only fix wasn't backported yet), this push will be rejected as non-fast-forward — that's the signal that step 4's backport rule was skipped. Backport the missing commit to `main` first, then re-run the snapshot. Use `--force-with-lease` only as a last resort, after confirming the divergent commits are accounted for on `main`.
 3. Soak the staging URL (`staging.bummer.app`) on phone + Mac with real Spotify auth.
 4. Bug found during soak → fix on `rc` directly (PR `fix/x` → `rc`), then backport to `main` (PR or cherry-pick). Soak continues — no reset. **Every rc-only fix MUST land on `main` before the next `rc` snapshot, or it gets clobbered.**
 5. Stable → open PR `rc` → `production`. CI runs (lint + tests). Merge with a merge commit (no squash, no rebase — the merge commit is the ship event and the revert target).
@@ -139,7 +139,7 @@ In a worktree, complete ALL of these steps before running `make dev-bg`:
 - **`vite: command not found`** in frontend log → `npm --prefix frontend install` was skipped
 - **Backend 8000 up but frontend 5173 missing** → check `/tmp/bsi-frontend.log` for errors
 
-- **Merging PRs** — never use `--auto` or `--admin` flags. When the user approves a merge, poll CI checks (`gh pr checks`) until they pass, then run `gh pr merge --squash --repo toofanian/bummer`. Do not ask the user to merge manually.
+- **Merging PRs** — never use `--auto` or `--admin` flags. When the user approves a merge, poll CI checks (`gh pr checks`) until they pass, then run `gh pr merge --squash --repo toofanian/bummer`. Do not ask the user to merge manually. **Exception:** `rc` → `production` PRs use a merge commit (`gh pr merge --merge`), not squash — see "Release flow" below for why.
 - Compatible with worktrees — agents can work in isolated worktrees on their branch
 - Never commit `.env` files or secrets
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -80,4 +80,7 @@ app.include_router(export.router)
 
 @app.get("/health")
 def health():
-    return {"status": "ok"}
+    return {
+        "status": "ok",
+        "sha": os.environ.get("VERCEL_GIT_COMMIT_SHA", "unknown"),
+    }

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -11,7 +11,8 @@ client = TestClient(app, follow_redirects=False)
 def test_health():
     response = client.get("/health")
     assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+    assert response.json()["status"] == "ok"
+    assert "sha" in response.json()
 
 
 # --- redeem-invite tests ---

--- a/docs/plans/2026-05-05-release-branches.md
+++ b/docs/plans/2026-05-05-release-branches.md
@@ -1,0 +1,470 @@
+# Release Branches Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Decouple production deploys from `main` by introducing `rc` (staging) and `production` long-lived branches, with manual promotion gates and a post-deploy smoke test.
+
+**Architecture:** Three branches — `main` (integration, preview deploys), `rc` (release candidate, soak target at `staging.bummer.app`), `production` (live). Promotion is manual: snapshot `main` → `rc`, soak, then PR `rc` → `production`. A new GitHub Action runs after each `production` push to verify `/health` on the live domain.
+
+**Tech Stack:** GitHub Actions (YAML), Vercel (manual config), Spotify Developer Dashboard (manual config), GitHub branch protection (manual config).
+
+**Spec:** `docs/specs/2026-05-04-release-branches-design.md`
+
+**Issue:** [#140](https://github.com/toofanian/bummer/issues/140)
+
+---
+
+## Task ordering note
+
+Tasks 1–3 are code changes that land via the normal PR-to-main flow on the current branch (`140-release-branches`). They are safe to merge with the old single-branch model still in place — the CI workflow change adds `production` and `rc` as additional triggers without removing `main`, and the smoke-test workflow only fires on pushes to `production` (which doesn't exist yet, so it's inert).
+
+Tasks 4–10 are the one-time live migration. They MUST be executed in order, by the owner, AFTER the PR for tasks 1–3 has merged to `main`. They are mostly manual UI/CLI steps and cannot be done by an agent.
+
+---
+
+## File Structure
+
+**Modified:**
+- `.github/workflows/ci.yml` — extend triggers to include PRs targeting `rc` and `production`
+- `CLAUDE.md` — update git workflow + preview deploy sections
+- (Create) `.github/workflows/prod-smoke-test.yml` — post-deploy `/health` check on `production` pushes
+
+**Not changed in code:** Vercel project settings, GitHub branch protection, Spotify redirect URIs, branch creation. These are documented as a runbook in Task 4 but executed manually.
+
+---
+
+## Task 1: Extend CI workflow to cover rc and production PRs
+
+**Files:**
+- Modify: `.github/workflows/ci.yml:3-5`
+
+**Context:** Currently CI only runs on PRs targeting `main`. After release branches are introduced, PRs will also target `rc` (bugfixes during soak) and `production` (the ship PR). All three need the same lint + test gates.
+
+- [ ] **Step 1: Update the `on:` trigger**
+
+Change lines 3–5 of `.github/workflows/ci.yml` from:
+
+```yaml
+on:
+  pull_request:
+    branches: [main]
+```
+
+to:
+
+```yaml
+on:
+  pull_request:
+    branches: [main, rc, production]
+```
+
+Leave the rest of the file unchanged.
+
+- [ ] **Step 2: Validate the YAML**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
+Expected: no output, exit code 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: run on PRs targeting rc and production [140]"
+```
+
+---
+
+## Task 2: Add post-deploy smoke test workflow
+
+**Files:**
+- Create: `.github/workflows/prod-smoke-test.yml`
+
+**Context:** When `production` is pushed, Vercel auto-deploys. We want a workflow that waits for the deploy, hits `/health`, and fails loudly if the live site is broken. The prod URL is stored as a repository variable `PROD_URL` (set during Task 4) so we don't hardcode the domain.
+
+The Vercel deploy is async — Vercel doesn't block on the GitHub push. We poll `${PROD_URL}/health` with a delay and retries to absorb the deploy latency and any cold start.
+
+- [ ] **Step 1: Create the workflow file**
+
+Create `.github/workflows/prod-smoke-test.yml` with this content:
+
+```yaml
+name: Production Smoke Test
+
+on:
+  push:
+    branches: [production]
+
+jobs:
+  smoke-test:
+    name: Smoke test /health on production
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for Vercel deploy to propagate
+        run: sleep 90
+
+      - name: Hit /health with retries
+        env:
+          PROD_URL: ${{ vars.PROD_URL }}
+        run: |
+          if [ -z "$PROD_URL" ]; then
+            echo "PROD_URL repository variable is not set" >&2
+            exit 1
+          fi
+
+          attempts=0
+          max_attempts=5
+          delay=20
+
+          while [ $attempts -lt $max_attempts ]; do
+            attempts=$((attempts + 1))
+            echo "Attempt $attempts: GET $PROD_URL/health"
+
+            http_code=$(curl -s -o /tmp/health.json -w "%{http_code}" --max-time 15 "$PROD_URL/health" || echo "000")
+            body=$(cat /tmp/health.json 2>/dev/null || echo "")
+
+            if [ "$http_code" = "200" ] && echo "$body" | grep -q '"status":"ok"'; then
+              echo "Smoke test passed: $body"
+              exit 0
+            fi
+
+            echo "Attempt $attempts failed (status=$http_code, body=$body). Retrying in ${delay}s..."
+            sleep $delay
+          done
+
+          echo "Smoke test failed after $max_attempts attempts" >&2
+          exit 1
+```
+
+- [ ] **Step 2: Validate the YAML**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/prod-smoke-test.yml'))"`
+Expected: no output, exit code 0.
+
+- [ ] **Step 3: Verify the existing `/health` response shape matches the assertion**
+
+Read `backend/main.py:81-83`. Confirm the endpoint returns `{"status": "ok"}`. The grep pattern in the workflow (`"status":"ok"`) must match this body verbatim (Python dict serialization removes the space; FastAPI/Starlette JSONResponse output is `{"status":"ok"}`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/prod-smoke-test.yml
+git commit -m "ci: add post-deploy smoke test on production push [140]"
+```
+
+---
+
+## Task 3: Update CLAUDE.md for release-branch workflow
+
+**Files:**
+- Modify: `CLAUDE.md` — "Git workflow" section and "Preview deploys" section
+
+**Context:** Several CLAUDE.md statements assume `main` is production. Update them. Also add the release flow steps and the rc-bugfix-then-backport rule.
+
+- [ ] **Step 1: Replace the "main is production" warning**
+
+Find the line in `CLAUDE.md` that begins:
+
+```
+- **`main` is production** — merging to main triggers a Vercel production deploy
+```
+
+Replace the entire bullet (one paragraph) with:
+
+```
+- **`production` is production** — merging to `production` triggers a Vercel production deploy to live users. Treat every merge to `production` as a release. Never push, force-push, or merge to `production` without passing CI and user approval. `main` is the integration branch and gets preview deploys per PR; merges to `main` do NOT deploy to prod.
+```
+
+- [ ] **Step 2: Add a "Release flow" subsection under "Git workflow"**
+
+Find the "Git workflow" heading (`## Git workflow`). After the existing bullets but before the "Local preview before PR" bullet, insert this new subsection:
+
+```markdown
+### Release flow (rc + production)
+
+Three long-lived branches: `main` (integration), `rc` (release candidate, deploys to `staging.bummer.app`), `production` (live).
+
+1. Feature work merges to `main` via PR (current behavior).
+2. When a batch is ready to ship, fast-forward `rc` to current `main` HEAD: `git push origin main:rc`. This is the code freeze.
+3. Soak the staging URL (`staging.bummer.app`) on phone + Mac with real Spotify auth.
+4. Bug found during soak → fix on `rc` directly (PR `fix/x` → `rc`), then backport to `main` (PR or cherry-pick). Soak continues — no reset. **Every rc-only fix MUST land on `main` before the next `rc` snapshot, or it gets clobbered.**
+5. Stable → open PR `rc` → `production`. CI runs (lint + tests). Merge with a merge commit (no squash, no rebase — the merge commit is the ship event and the revert target).
+6. Tag the release: `git tag vX.Y.Z && git push --tags` (manual semver bump).
+7. Vercel auto-deploys `production`. The `Production Smoke Test` workflow hits `/health` and fails loudly if broken.
+
+**Rollback:**
+- Fast: Vercel UI → Instant Rollback to prior production deployment.
+- Durable: `git revert -m 1 <merge-sha>` on `production` and push.
+```
+
+- [ ] **Step 3: Update the "Preview deploys" section**
+
+Find the heading `## Preview deploys`. Add a new bullet at the end of the existing bullet list:
+
+```markdown
+- The `rc` branch deploys to `staging.bummer.app` (via Vercel branch deploy + custom domain). Unlike preview deploys, `rc` uses **direct Spotify OAuth** (its callback URI is registered in the Spotify Dashboard) — not the callback proxy. RC shares the prod Supabase DB, same as preview deploys.
+```
+
+- [ ] **Step 4: Verify the file still reads cleanly**
+
+Open `CLAUDE.md` and read the modified sections top-to-bottom. Confirm:
+- No duplicate "main is production" wording
+- The release flow bullets are numbered 1–7 with no gaps
+- The `staging.bummer.app` bullet is grouped with the other preview-deploy bullets
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: update CLAUDE.md for release-branch workflow [140]"
+```
+
+---
+
+## Task 3.5: Open PR, get tasks 1–3 to main
+
+**Context:** The remaining tasks (4–10) are manual live-migration steps. They need the workflow files and docs from tasks 1–3 already on `main`, because the migration creates the `production` branch by branching from `main`.
+
+- [ ] **Step 1: Push the branch and open the PR**
+
+```bash
+git push -u origin 140-release-branches
+gh pr create --title "Release branches: workflows + docs [140]" --body "$(cat <<'EOF'
+## Summary
+- Extend CI to run on PRs targeting `rc` and `production`
+- Add post-deploy smoke test workflow that hits `/health` on `production` pushes
+- Update CLAUDE.md to document the rc + production release flow
+
+## Test plan
+- [x] YAML validates for both workflow files
+- [x] `/health` response shape matches the smoke test assertion
+- [ ] After merge, owner runs the live migration runbook (Tasks 4–10)
+
+Closes part of #140 (workflow/docs); branch creation and Vercel/Spotify config done manually post-merge.
+EOF
+)"
+```
+
+- [ ] **Step 2: Wait for CI green and user approval, then merge**
+
+Poll `gh pr checks` until green. After user approves: `gh pr merge --squash --repo toofanian/bummer`.
+
+---
+
+## Task 4: One-time migration — create `production` branch and protect it
+
+**Context:** From here down is a runbook for the owner. No agent should attempt these steps. Each step is reversible until step 5 (Vercel cutover).
+
+**Pre-flight check:** The PR from Task 3.5 must be merged to `main`. Verify: `git fetch origin && git log origin/main --oneline -5` includes the workflow + CLAUDE.md commits.
+
+- [ ] **Step 1: Create `production` branch from current main**
+
+```bash
+git fetch origin
+git push origin origin/main:refs/heads/production
+```
+
+This pushes a new `production` branch pointing at the same SHA as `main`. No local checkout needed.
+
+- [ ] **Step 2: Add branch protection on `production`**
+
+GitHub UI: Settings → Branches → Add rule. Branch name pattern: `production`. Enable:
+- Require a pull request before merging
+- Require status checks to pass before merging — select: `Lint (ruff)`, `Backend Tests (pytest)`, `Frontend Tests (vitest)`
+- Require branches to be up to date before merging
+- Do not allow bypassing the above settings
+- Restrict pushes (no force push, no deletion)
+
+Save the rule. Verify: `gh api repos/toofanian/bummer/branches/production/protection` returns the rule (not 404).
+
+- [ ] **Step 3: Tag the current state as v1.0.0**
+
+```bash
+git fetch origin
+git tag v1.0.0 origin/production
+git push origin v1.0.0
+```
+
+---
+
+## Task 5: One-time migration — Vercel production branch cutover
+
+**Context:** This is the live cutover. Until this step, prod still deploys from `main`. After this step, prod only deploys from `production`.
+
+- [ ] **Step 1: Change Vercel production branch**
+
+Vercel Dashboard → Project (bummer) → Settings → Git → Production Branch. Change from `main` to `production`. Save.
+
+- [ ] **Step 2: Verify prod still works**
+
+Open the live prod URL. Confirm normal load + `/health` returns 200. Since `production` was created from `main` at the same SHA, no redeploy should be needed, but Vercel may trigger one — wait for it to finish and verify.
+
+- [ ] **Step 3: Set the `PROD_URL` repository variable**
+
+```bash
+gh variable set PROD_URL --body "https://<your-prod-domain>" --repo toofanian/bummer
+```
+
+Replace `<your-prod-domain>` with the actual production domain (e.g. `https://bummer.vercel.app` or your custom domain). The smoke-test workflow reads this.
+
+- [ ] **Step 4: Smoke test the smoke test**
+
+Push an empty commit to `production` to verify the workflow runs:
+
+```bash
+git fetch origin
+git checkout -b verify-smoke-test origin/production
+git commit --allow-empty -m "chore: verify smoke test workflow [140]"
+git push origin verify-smoke-test
+gh pr create --base production --head verify-smoke-test --title "chore: verify smoke test [140]" --body "Empty commit to confirm prod-smoke-test.yml runs and passes."
+```
+
+After merge to `production`: watch the Actions tab. The `Production Smoke Test` workflow should run, wait 90s, hit `/health`, and pass. If it fails, debug and fix before continuing.
+
+---
+
+## Task 6: One-time migration — create `rc` branch + Vercel staging domain
+
+- [ ] **Step 1: Create `rc` branch from current main**
+
+```bash
+git fetch origin
+git push origin origin/main:refs/heads/rc
+```
+
+- [ ] **Step 2: Add branch protection on `rc`**
+
+GitHub UI: Settings → Branches → Add rule. Branch name pattern: `rc`. Enable:
+- Require a pull request before merging — but allow administrators (you) to bypass for the fast-forward snapshots
+- Require status checks to pass — same three checks as production
+- Restrict pushes: no force push, no deletion. Allow direct push (needed for fast-forward snapshots).
+
+Save.
+
+- [ ] **Step 3: Attach `staging.bummer.app` to `rc` branch in Vercel**
+
+Vercel Dashboard → Project → Settings → Domains. Add `staging.bummer.app` (or your chosen subdomain). Configure it to deploy from the `rc` branch:
+- Click the new domain → Edit → Git Branch → set to `rc`. Save.
+
+DNS: add a CNAME for `staging.bummer.app` pointing at `cname.vercel-dns.com` (or whatever Vercel instructs). Wait for SSL cert to provision.
+
+- [ ] **Step 4: Configure env vars for the `rc` branch**
+
+Vercel Dashboard → Settings → Environment Variables. For each prod env var, add an entry scoped to the `rc` branch (or set the branch to use Production scope). The full list of env vars is in `CLAUDE.md` under "Local dev setup" — Spotify, Supabase, etc. RC must use the same values as Production scope (it shares the prod DB and prod Spotify app).
+
+- [ ] **Step 5: Verify staging deploys**
+
+Vercel Dashboard → Deployments. Confirm a deploy was triggered for `rc`. Once finished, open `https://staging.bummer.app/health`. Expect 200 + `{"status":"ok"}`.
+
+---
+
+## Task 7: One-time migration — Spotify redirect URI for staging
+
+- [ ] **Step 1: Add staging callback URI to Spotify Dashboard**
+
+Spotify Developer Dashboard → your app → Edit Settings → Redirect URIs. Add:
+
+```
+https://staging.bummer.app/auth/callback
+```
+
+Save.
+
+- [ ] **Step 2: Verify direct OAuth flow on staging**
+
+Open `https://staging.bummer.app` on phone or Mac. Sign in with Google, then connect Spotify. Confirm the OAuth round-trip completes without going through the callback proxy. (You can verify by watching Network tab — the callback hits staging.bummer.app directly, not the prod backend.)
+
+---
+
+## Task 8: One-time migration — empty release rehearsal
+
+**Context:** Run a full release cycle with no real changes to verify the pipeline end-to-end.
+
+- [ ] **Step 1: Snapshot `rc` from `main`**
+
+```bash
+git fetch origin
+git push origin origin/main:rc
+```
+
+- [ ] **Step 2: Verify staging deploys and works**
+
+Wait for Vercel deploy on `rc`. Open `staging.bummer.app`, log in, do a quick smoke test (load library, play a track if Premium).
+
+- [ ] **Step 3: Open ship PR**
+
+```bash
+gh pr create --base production --head rc --title "Release v1.0.1 [140]" --body "Empty release rehearsal. No changes."
+```
+
+- [ ] **Step 4: Wait for CI, merge with merge commit**
+
+`gh pr checks` until green. Then merge — important, NOT squash:
+
+```bash
+gh pr merge --merge --repo toofanian/bummer
+```
+
+- [ ] **Step 5: Tag the release**
+
+```bash
+git fetch origin
+git tag v1.0.1 origin/production
+git push origin v1.0.1
+```
+
+- [ ] **Step 6: Verify smoke test passes**
+
+Watch GitHub Actions → `Production Smoke Test`. Should pass within ~3 minutes of the merge.
+
+- [ ] **Step 7: Verify prod still works**
+
+Open prod URL, log in, basic smoke test.
+
+---
+
+## Task 9: One-time migration — practice rollback
+
+**Context:** Verify both rollback paths work before you need them under pressure.
+
+- [ ] **Step 1: Vercel Instant Rollback dry run**
+
+Vercel Dashboard → Deployments → previous production deploy → "..." menu → Promote to Production. Confirm prod URL serves the prior build. Then promote the latest deploy back. Document the click path in your head.
+
+- [ ] **Step 2: `git revert` dry run on a throwaway branch**
+
+```bash
+git fetch origin
+git checkout -b test-revert origin/production
+git revert -m 1 HEAD  # the merge commit from Task 8
+```
+
+Verify the revert produces a clean diff. Discard the branch:
+
+```bash
+git checkout -
+git branch -D test-revert
+```
+
+Do NOT push the revert during the rehearsal.
+
+---
+
+## Task 10: Close out
+
+- [ ] **Step 1: Close issue #140**
+
+```bash
+gh issue close 140 --repo toofanian/bummer --comment "Release branch model live. main → rc → production with manual promotion gates, semver tags, and post-deploy smoke test. Spec: docs/specs/2026-05-04-release-branches-design.md. Plan: docs/plans/2026-05-05-release-branches.md."
+```
+
+- [ ] **Step 2: Update BACKLOG.md if it tracks this item**
+
+Move the release-branches entry to the completed section, link issue #140 and the spec.
+
+- [ ] **Step 3: Commit any backlog changes**
+
+```bash
+git add BACKLOG.md
+git commit -m "chore: mark release branches done in backlog [140]"
+git push
+```

--- a/docs/specs/2026-05-04-release-branches-design.md
+++ b/docs/specs/2026-05-04-release-branches-design.md
@@ -1,0 +1,126 @@
+# Release Branches Design
+
+**Issue:** [#140](https://github.com/toofanian/bummer/issues/140)
+**Date:** 2026-05-04
+**Status:** Approved, ready for implementation plan
+
+## Problem
+
+Today, every merge to `main` deploys straight to production. There is no buffer between "tests pass" and "users see it." We want:
+
+- Ability to batch changes into intentional releases
+- A soak period where a frozen build runs against real usage before promotion
+- Easy, fast rollbacks
+- Foundation for versioning and changelogs
+
+## Solution overview
+
+Three long-lived branches with manual promotion gates:
+
+| Branch | Purpose | Deploys to |
+|--------|---------|------------|
+| `main` | Integration. PR target for all feature work. | Per-PR Vercel preview URLs (unchanged) |
+| `rc` | Release candidate. Snapshot of `main` at freeze time. Soak target. | `staging.bummer.app` (Vercel branch deploy + custom domain) |
+| `production` | Live users. | Production domain (unchanged) |
+
+Promotion is manual at every step. Solo dev cadence — no scheduled releases.
+
+## Release flow
+
+1. Feature work merges to `main` via PR (current behavior).
+2. When a batch is ready to ship, fast-forward `rc` to current `main` HEAD: `git push origin main:rc`. This is the code freeze.
+3. Vercel deploys `rc` to `staging.bummer.app`. Owner soaks against the staging URL using real Spotify auth and the prod Supabase database.
+4. **Bug found during soak:** fix on `rc` directly (PR `fix/x` → `rc`), then backport to `main` (cherry-pick or PR `fix/x` → `main`). Soak continues — no reset.
+5. Stable → open PR `rc` → `production`. CI runs (lint + tests). Merge with a merge commit (no squash, no rebase).
+6. Manually tag `vMAJOR.MINOR.PATCH` on `production` and push: `git tag vX.Y.Z && git push --tags`.
+7. Vercel auto-deploys `production`. Post-deploy smoke test workflow hits `/health` on the live domain. Failure = loud notification.
+
+### Backport discipline
+
+Every fix that lands on `rc` MUST also land on `main` before the next `rc` snapshot, or it will be clobbered when `rc` fast-forwards. This is enforced by convention, not tooling.
+
+## Rollback
+
+Two mechanisms, used together:
+
+- **Fast (Vercel Instant Rollback):** Vercel UI → promote prior production deployment. Seconds. Use when the live site is broken right now.
+- **Durable (`git revert`):** `git revert -m 1 <merge-sha>` on `production` and push. Aligns git truth with deployed state. Use after the fast rollback to keep history honest, or when the fix needs to stick across future deploys.
+
+## Branch protection
+
+| Branch | Rules |
+|--------|-------|
+| `main` | PR required, CI must pass, no direct push, no force push (current). |
+| `rc` | PR required for bugfixes. CI must pass. Direct fast-forward push from owner allowed for snapshots. No force push. |
+| `production` | PR required, CI must pass, no direct push, no force push. |
+
+## Vercel configuration
+
+- **Production branch setting:** `main` → `production`
+- **Staging custom domain:** `staging.bummer.app` attached to `rc` branch deploys
+- **Env vars:** `rc` branch uses production-scoped env vars (since RC shares the prod Supabase DB and the prod Spotify app)
+- **Preview deploys:** unchanged — every PR to `main` gets a preview URL with the existing OAuth proxy behavior
+
+## Spotify OAuth
+
+- Register `https://staging.bummer.app/auth/callback` as a second Spotify redirect URI
+- `rc` branch uses direct Spotify OAuth, not the preview-deploy callback proxy
+- Reason: soak should exercise the real callback path, not the proxy. Preview deploys keep using the proxy as today.
+
+## Database
+
+- `rc` shares the production Supabase database (free tier, no Supabase branching available)
+- This matches existing preview-deploy behavior
+- Migration discipline already in place: apply migrations to prod BEFORE merging the PR that depends on them. Same rule applies to `rc` — if `rc` requires a migration, it must already be applied to prod.
+
+## CI / GitHub Actions
+
+### CI on production PRs
+
+Extend the existing main-PR CI workflow to also trigger on PRs targeting `production`. Same lint + test matrix.
+
+### Post-deploy smoke test (new workflow)
+
+- **Trigger:** `push` to `production`
+- **Steps:**
+  1. Wait for Vercel deploy to finish (poll Vercel API or use deployment status webhook)
+  2. `curl https://<prod-domain>/health`, expect 200 with the existing `/health` response shape
+  3. Retry 3× with backoff to tolerate cold start
+  4. Fail the workflow loudly on non-200 or timeout (GitHub notification)
+- **Catches:** missing/wrong prod env vars, ASGI shim breakage, Supabase prod connection issues, frontend bundle 500s on first request
+
+### Tag automation
+
+Manual for v1. Owner runs `git tag vX.Y.Z && git push --tags` after merging to `production`. Revisit if ship rate exceeds weekly.
+
+## Docs updates (CLAUDE.md)
+
+- Replace "`main` is production" warning with "`production` branch is production"
+- Add the release flow steps to the "Git workflow" section
+- Update "Preview deploys" section to mention `staging.bummer.app` (rc branch) alongside preview URLs
+- Document the rc-bugfix-then-backport rule
+
+## One-time migration steps
+
+Order matters. Each step is reversible until step 3.
+
+1. Create `production` branch from current `main` HEAD; push.
+2. Add branch protection on `production` (PR required, CI required, no direct/force push).
+3. Vercel: change production branch from `main` to `production`. Verify next deploy from `production` works.
+4. Tag current state `v1.0.0` on `production` and push tag.
+5. Create `rc` branch from current `main` HEAD; push.
+6. Vercel: attach `staging.bummer.app` to `rc` branch deploys. Configure env vars to mirror prod.
+7. Spotify Dashboard: add `https://staging.bummer.app/auth/callback` as a redirect URI.
+8. Add branch protection on `rc` (PR for bugfixes, CI required, no force push, allow fast-forward direct push from owner).
+9. Add `production` as a target branch in the existing CI workflow. Add the new smoke-test workflow.
+10. Update CLAUDE.md.
+11. Run a full empty-release rehearsal (snapshot `rc` from `main`, promote `rc` → `production` with no real changes) to verify the full pipeline works end-to-end.
+
+## Out of scope
+
+- Automated tag generation / release-please / conventional commits
+- Scheduled/automated promotion (cron-based releases)
+- Multiple parallel release branches (`release/vX.Y` per release)
+- Supabase branching for staging (requires Pro tier, $25/mo)
+- Changelog generation
+- Hotfix branches that bypass `rc`


### PR DESCRIPTION
## Summary
- Extend CI to run on PRs targeting `rc` and `production` (`.github/workflows/ci.yml`)
- New `Production Smoke Test` workflow that hits `/health` on production pushes, parses with `jq`, and asserts deployed SHA matches `github.sha` to defeat the deploy race
- `/health` now returns `VERCEL_GIT_COMMIT_SHA` so the smoke test can confirm the new deploy is live
- CLAUDE.md updated: `production` is production, full `rc → production` release flow + rollback, exception note on squash-vs-merge, divergence handling on `main:rc` snapshot

## Test plan
- [x] YAML validates for both workflow files
- [x] ruff check + ruff format pass on backend
- [x] `/health` shape change is mechanical; CI pytest job will validate on this PR
- [ ] After merge to main, owner runs Tasks 4–10 from `docs/plans/2026-05-05-release-branches.md` (branch creation, Vercel cutover, Spotify staging URI, branch protection, empty release rehearsal, rollback rehearsal)

Spec: `docs/specs/2026-05-04-release-branches-design.md`
Plan: `docs/plans/2026-05-05-release-branches.md`
Closes part of #140 (workflow + docs); live migration is the runbook in the plan.